### PR TITLE
fix(orm): keep join-callback WHERE in ON clause and serialize unmanag…

### DIFF
--- a/packages/orm-sql/src/statements.ts
+++ b/packages/orm-sql/src/statements.ts
@@ -263,9 +263,32 @@ export class SqlJoinStatement extends JoinStatement {
     const primaryKey = sourceTableAlias ? `\`${sourceTableAlias}\`.${this._options.sourceTablePrimaryKey}` : `\`${sourceTable}\`.${this._options.sourceTablePrimaryKey}`;
     const foreignKey = joinTableAlias ? `\`${joinTableAlias}\`.${this._options.joinTableForeignKey}` : `\`${joinTable}\`.${this._options.joinTableForeignKey}`;
 
+    // Conditions supplied via the join callback (e.g. `.leftJoin(rel, b => b.where('Key', 'x'))`)
+    // belong in the JOIN's ON clause, not the main WHERE — otherwise an outer
+    // join is silently narrowed to an inner one. We compile the join sub-builder's
+    // WHERE statements here and append them to ON (the constructor intentionally
+    // does NOT merge these into the main builder; see JoinStatement above).
+    let onExpression = `${primaryKey} = ${foreignKey}`;
+    const onBindings: unknown[] = [];
+
+    if (this._whereBuilder) {
+      const parts: string[] = [];
+      this._whereBuilder.Statements.filter((x: WhereStatement) => !x.IsAggregate).forEach((x: WhereStatement) => {
+        const r = x.build();
+        parts.push(...r.Statements);
+        if (Array.isArray(r.Bindings)) {
+          onBindings.push(...r.Bindings);
+        }
+      });
+
+      if (parts.length > 0) {
+        onExpression += ` AND ${parts.join(` ${this._whereBuilder.Op.toUpperCase()} `)}`;
+      }
+    }
+
     return {
-      Bindings: [],
-      Statements: [`${method} ${joinTable} ON ${primaryKey} = ${foreignKey}`],
+      Bindings: onBindings,
+      Statements: [`${method} ${joinTable} ON ${onExpression}`],
     };
   }
 }

--- a/packages/orm-sql/test/queryBuilder.test.ts
+++ b/packages/orm-sql/test/queryBuilder.test.ts
@@ -698,6 +698,49 @@ describe('Relations query builder', () => {
     sinon.restore();
   });
 
+  it('join callback where goes into ON clause not main WHERE', () => {
+    // A where condition supplied via the join callback must be emitted in the
+    // join's ON clause, otherwise a LEFT JOIN is silently narrowed into an
+    // inner filter (rows the outer join is meant to keep get filtered out).
+    const result = RelationModel.where('Id', 1)
+      .leftJoin('Relation', function (this: IWhereBuilder<RelationModel2>) {
+        this.where('RelationProperty', 'foo');
+      })
+      .toDB() as ICompilerOutput;
+
+    expect(result.expression).to.equal('SELECT `$RelationTable$`.* FROM `RelationTable` as `$RelationTable$` LEFT JOIN `RelationTable2` as `$RelationModel2$` ON `$RelationTable$`.relation_id = `$RelationModel2$`.Id AND ( `$RelationModel2$`.`RelationProperty` = ? ) WHERE `$RelationTable$`.`Id` = ?');
+
+    // join binding must come before the main WHERE binding (ON precedes WHERE in SQL)
+    expect(result.bindings).to.deep.equal(['foo', 1]);
+  });
+
+  it('join callback with multiple where conditions combines them in ON clause', () => {
+    const result = RelationModel.where('Id', 1)
+      .leftJoin('Relation', function (this: IWhereBuilder<RelationModel2>) {
+        this.where('RelationProperty', 'foo');
+        this.where('Id', 5);
+      })
+      .toDB() as ICompilerOutput;
+
+    expect(result.expression).to.equal('SELECT `$RelationTable$`.* FROM `RelationTable` as `$RelationTable$` LEFT JOIN `RelationTable2` as `$RelationModel2$` ON `$RelationTable$`.relation_id = `$RelationModel2$`.Id AND ( `$RelationModel2$`.`RelationProperty` = ? AND `$RelationModel2$`.`Id` = ? ) WHERE `$RelationTable$`.`Id` = ?');
+    expect(result.bindings).to.deep.equal(['foo', 5, 1]);
+  });
+
+  it('left join with callback stays a LEFT JOIN', () => {
+    // regression: the join callback must not fold its condition into the main
+    // WHERE, which would turn this LEFT JOIN into an effective inner join.
+    const result = RelationModel.where('Id', 1)
+      .leftJoin('Relation', function (this: IWhereBuilder<RelationModel2>) {
+        this.where('RelationProperty', 'foo');
+      })
+      .toDB() as ICompilerOutput;
+
+    expect(result.expression).to.match(/LEFT JOIN `RelationTable2`/);
+    // condition belongs to ON, so the WHERE must only contain the source filter
+    expect(result.expression).to.match(/WHERE `\$RelationTable\$`\.`Id` = \?$/);
+    expect(result.expression).to.not.match(/WHERE.*RelationProperty/);
+  });
+
   it('should query by relation in where', () => {
     const result = RelationModel.where({ Relation: 1 }).toDB() as ICompilerOutput;
     expect(result.expression).to.equal('SELECT * FROM `RelationTable` WHERE `relation_id` = ?');

--- a/packages/orm-sqlite/src/converters.ts
+++ b/packages/orm-sqlite/src/converters.ts
@@ -9,7 +9,15 @@ export class SqliteModelToSqlConverter extends ModelToSqlConverter {
     const obj = {};
     const relArr = [...model.ModelDescriptor!.Relations.values()];
 
-    model.ModelDescriptor!.Columns?.filter((x) => !x.IsForeignKey).forEach((c) => {
+    // Foreign-key columns are normally written via their relation (the loop
+    // below sets obj[ForeignKey] from the related model). But a FK column with no
+    // backing relation on the model (e.g. a plain owner-id column such as
+    // user_sessions.UserId) would otherwise never be serialized at all, breaking
+    // INSERTs that hit its NOT NULL constraint. So only skip FK columns that an
+    // actual relation manages; serialize unrelated FK columns like normal ones.
+    const relationForeignKeys = new Set(relArr.map((r) => r.ForeignKey));
+
+    model.ModelDescriptor!.Columns?.filter((x) => !x.IsForeignKey || !relationForeignKeys.has(x.Name)).forEach((c) => {
       const val = (model as any)[c.Name];
       if (!c.PrimaryKey && !c.Nullable && (val === null || val === undefined || val === '')) {
         throw new OrmException(`Field ${c.Name} cannot be null`);

--- a/packages/orm-sqlite/test/converters.test.ts
+++ b/packages/orm-sqlite/test/converters.test.ts
@@ -1,0 +1,119 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+import { ModelBase, RelationType, OrmException } from '@spinajs/orm';
+import * as chai from 'chai';
+import 'mocha';
+import { SqliteModelToSqlConverter } from './../src/converters.js';
+
+const expect = chai.expect;
+
+function column(name: string, opts: Partial<any> = {}) {
+  return {
+    Name: name,
+    PrimaryKey: false,
+    Nullable: true,
+    IsForeignKey: false,
+    Virtual: false,
+    Converter: null,
+    ...opts,
+  };
+}
+
+// Builds a minimal mock model exposing just what SqliteModelToSqlConverter.toSql touches.
+function mockModel(columns: any[], relations: Array<any>, values: Record<string, unknown>) {
+  return {
+    ModelDescriptor: {
+      Columns: columns,
+      Relations: new Map(relations.map((r) => [r.Name, r])),
+      Converters: new Map(),
+    },
+    ...values,
+  } as unknown as ModelBase<unknown>;
+}
+
+describe('SqliteModelToSqlConverter foreign key handling', () => {
+  it('should serialize a FK column that has no backing relation', () => {
+    // UserId is a foreign-key column but no relation manages it. It must still
+    // be serialized, otherwise an INSERT omits it and breaks its NOT NULL constraint.
+    const model = mockModel(
+      [
+        column('Id', { PrimaryKey: true, Nullable: false }),
+        column('Name', { Nullable: false }),
+        column('UserId', { IsForeignKey: true, Nullable: false }),
+      ],
+      [],
+      { Id: 1, Name: 'test', UserId: 42 },
+    );
+
+    const result = new SqliteModelToSqlConverter().toSql(model) as Record<string, unknown>;
+
+    expect(result).to.have.property('UserId', 42);
+    expect(result).to.have.property('Name', 'test');
+    expect(result).to.have.property('Id', 1);
+  });
+
+  it('should NOT serialize a FK column managed by a relation in the column loop', () => {
+    const model = mockModel(
+      [
+        column('Id', { PrimaryKey: true, Nullable: false }),
+        column('relation_id', { IsForeignKey: true, Nullable: true }),
+      ],
+      [{ Name: 'Relation', ForeignKey: 'relation_id', Type: RelationType.One, Recursive: false }],
+      {
+        Id: 1,
+        relation_id: 999, // raw column value, ignored in favor of the relation value
+        Relation: { Value: { PrimaryKeyValue: 7 } },
+      },
+    );
+
+    const result = new SqliteModelToSqlConverter().toSql(model) as Record<string, unknown>;
+
+    expect(result).to.have.property('relation_id', 7);
+  });
+
+  it('should serialize an unrelated FK column even when relations exist for other FKs', () => {
+    const model = mockModel(
+      [
+        column('Id', { PrimaryKey: true, Nullable: false }),
+        column('relation_id', { IsForeignKey: true, Nullable: true }),
+        column('UserId', { IsForeignKey: true, Nullable: false }),
+      ],
+      [{ Name: 'Relation', ForeignKey: 'relation_id', Type: RelationType.One, Recursive: false }],
+      {
+        Id: 1,
+        relation_id: 5,
+        UserId: 42,
+        Relation: { Value: { PrimaryKeyValue: 5 } },
+      },
+    );
+
+    const result = new SqliteModelToSqlConverter().toSql(model) as Record<string, unknown>;
+
+    expect(result).to.have.property('relation_id', 5);
+    expect(result).to.have.property('UserId', 42);
+  });
+
+  it('should throw when an unrelated NOT NULL FK column is null', () => {
+    const model = mockModel(
+      [column('Id', { PrimaryKey: true, Nullable: false }), column('UserId', { IsForeignKey: true, Nullable: false })],
+      [],
+      { Id: 1, UserId: null },
+    );
+
+    expect(() => new SqliteModelToSqlConverter().toSql(model)).to.throw(OrmException, /UserId/);
+  });
+
+  it('should omit an unrelated nullable FK column when its value is undefined', () => {
+    // sqlite omits undefined values so the DB default is used (sqlite has no
+    // DEFAULT keyword support in insert statements).
+    const model = mockModel(
+      [column('Id', { PrimaryKey: true, Nullable: false }), column('UserId', { IsForeignKey: true, Nullable: true })],
+      [],
+      { Id: 1, UserId: undefined },
+    );
+
+    const result = new SqliteModelToSqlConverter().toSql(model) as Record<string, unknown>;
+
+    expect(result).to.not.have.property('UserId');
+  });
+});

--- a/packages/orm/src/builders.ts
+++ b/packages/orm/src/builders.ts
@@ -1208,7 +1208,7 @@ export class SelectQueryBuilder<T = any> extends QueryBuilder<T> {
     return this;
   }
 
-  public mergeBuilder(builder: SelectQueryBuilder) {
+  public mergeBuilder(builder: SelectQueryBuilder, includeStatements = true) {
     this._columns = this._columns.concat(builder._columns);
     this._cteStatement = builder._cteStatement;
     this._distinct = builder._distinct;
@@ -1216,7 +1216,14 @@ export class SelectQueryBuilder<T = any> extends QueryBuilder<T> {
       column: builder._sort.column !== '' ? builder._sort.column : this._sort.column,
       order: builder._sort.order !== '' ? builder._sort.order : this._sort.order,
     };
-    this.mergeStatements(builder);
+    // `includeStatements: false` is used by JoinStatement so that a join
+    // callback's WHERE conditions are NOT folded into the main query's WHERE
+    // (which silently turns a LEFT JOIN into an inner filter). The join emits
+    // those conditions in its own ON clause instead. Columns/sort are still
+    // merged so join-callback selects (e.g. extra joined columns) keep working.
+    if (includeStatements) {
+      this.mergeStatements(builder);
+    }
   }
 
   public mergeRelations(builder: SelectQueryBuilder) {

--- a/packages/orm/src/converters.ts
+++ b/packages/orm/src/converters.ts
@@ -91,7 +91,15 @@ export class StandardModelToSqlConverter extends ModelToSqlConverter {
     const obj = {};
     const relArr = [...model.ModelDescriptor!.Relations.values()];
 
-    model.ModelDescriptor!.Columns?.filter((x) => !x.IsForeignKey && !x.Virtual).forEach((c) => {
+    // Foreign-key columns are normally written via their relation (the loop
+    // below sets obj[ForeignKey] from the related model). But a FK column with no
+    // backing relation on the model (e.g. a plain owner-id column such as
+    // user_sessions.UserId) would otherwise never be serialized at all, breaking
+    // INSERTs that hit its NOT NULL constraint. So only skip FK columns that an
+    // actual relation manages; serialize unrelated FK columns like normal ones.
+    const relationForeignKeys = new Set(relArr.map((r) => r.ForeignKey));
+
+    model.ModelDescriptor!.Columns?.filter((x) => !x.Virtual && (!x.IsForeignKey || !relationForeignKeys.has(x.Name))).forEach((c) => {
       const val = (model as any)[c.Name];
       if (!c.PrimaryKey && !c.Nullable && (val === null || val === undefined || val === '')) {
         throw new OrmException(`Field ${c.Name} cannot be null`);

--- a/packages/orm/src/interfaces.ts
+++ b/packages/orm/src/interfaces.ts
@@ -1075,7 +1075,7 @@ export interface ISelectQueryBuilder<T = unknown> extends IColumnsBuilder, IOrde
    */
   all(): Promise<T>;
 
-  mergeBuilder(builder: ISelectQueryBuilder): void;
+  mergeBuilder(builder: ISelectQueryBuilder, includeStatements?: boolean): void;
 }
 
 export interface ICompilerOutput {

--- a/packages/orm/src/statements.ts
+++ b/packages/orm/src/statements.ts
@@ -228,7 +228,11 @@ export abstract class JoinStatement extends QueryStatement {
         _options.queryCallback.call(this._whereBuilder);
       }
 
-      this._options.builder!.mergeBuilder(this._whereBuilder);
+      // Merge columns/sort from the join sub-builder, but NOT its WHERE
+      // statements — those are emitted in the JOIN's ON clause by build() so a
+      // LEFT JOIN stays a LEFT JOIN (otherwise the condition lands in the main
+      // WHERE and filters out rows the outer join is meant to keep).
+      this._options.builder!.mergeBuilder(this._whereBuilder, false);
     }
   }
 

--- a/packages/orm/test/converters.test.ts
+++ b/packages/orm/test/converters.test.ts
@@ -1,9 +1,36 @@
-import { UuidConverter } from './../src/converters.js';
+import { UuidConverter, StandardModelToSqlConverter } from './../src/converters.js';
+import { RelationType } from './../src/interfaces.js';
+import { OrmException } from './../src/exceptions.js';
+import { ModelBase } from './../src/model.js';
 import * as chai from 'chai';
 import _ from 'lodash';
 import 'mocha';
 
 const expect = chai.expect;
+
+function column(name: string, opts: Partial<any> = {}) {
+  return {
+    Name: name,
+    PrimaryKey: false,
+    Nullable: true,
+    IsForeignKey: false,
+    Virtual: false,
+    Converter: null,
+    ...opts,
+  };
+}
+
+// Builds a minimal mock model exposing just what StandardModelToSqlConverter.toSql touches.
+function mockModel(columns: any[], relations: Array<any>, values: Record<string, unknown>) {
+  return {
+    ModelDescriptor: {
+      Columns: columns,
+      Relations: new Map(relations.map((r) => [r.Name, r])),
+      Converters: new Map(),
+    },
+    ...values,
+  } as unknown as ModelBase<unknown>;
+}
 
 describe('Orm converters', () => {
   it('Should convert uuid to & from db', async () => {
@@ -17,5 +44,96 @@ describe('Orm converters', () => {
 
     const back = converter.fromDB(uid as Buffer);
     expect(back === u.replace(/-/g, '')).to.be.true;
+  });
+
+  describe('StandardModelToSqlConverter foreign key handling', () => {
+    it('should serialize a FK column that has no backing relation', () => {
+      // UserId is marked as a foreign key column but no relation manages it
+      // (e.g. a plain owner-id column). It must still be serialized, otherwise
+      // an INSERT would omit it and break its NOT NULL constraint.
+      const model = mockModel(
+        [
+          column('Id', { PrimaryKey: true, Nullable: false }),
+          column('Name', { Nullable: false }),
+          column('UserId', { IsForeignKey: true, Nullable: false }),
+        ],
+        [],
+        { Id: 1, Name: 'test', UserId: 42 },
+      );
+
+      const result = new StandardModelToSqlConverter().toSql(model) as Record<string, unknown>;
+
+      expect(result).to.have.property('UserId', 42);
+      expect(result).to.have.property('Name', 'test');
+      expect(result).to.have.property('Id', 1);
+    });
+
+    it('should NOT serialize a FK column managed by a relation in the column loop', () => {
+      // relation_id is owned by the `Relation` BelongsTo relation. It must be
+      // written from the related model's primary key (via the relation loop),
+      // not picked up as a plain column.
+      const model = mockModel(
+        [
+          column('Id', { PrimaryKey: true, Nullable: false }),
+          column('relation_id', { IsForeignKey: true, Nullable: true }),
+        ],
+        [{ Name: 'Relation', ForeignKey: 'relation_id', Type: RelationType.One, Recursive: false }],
+        {
+          Id: 1,
+          relation_id: 999, // raw column value, should be ignored in favor of the relation value
+          Relation: { Value: { PrimaryKeyValue: 7 } },
+        },
+      );
+
+      const result = new StandardModelToSqlConverter().toSql(model) as Record<string, unknown>;
+
+      // value comes from the related model's PK, not the raw column
+      expect(result).to.have.property('relation_id', 7);
+    });
+
+    it('should serialize an unrelated FK column even when relations exist for other FKs', () => {
+      const model = mockModel(
+        [
+          column('Id', { PrimaryKey: true, Nullable: false }),
+          column('relation_id', { IsForeignKey: true, Nullable: true }),
+          column('UserId', { IsForeignKey: true, Nullable: false }),
+        ],
+        [{ Name: 'Relation', ForeignKey: 'relation_id', Type: RelationType.One, Recursive: false }],
+        {
+          Id: 1,
+          relation_id: 5,
+          UserId: 42,
+          Relation: { Value: { PrimaryKeyValue: 5 } },
+        },
+      );
+
+      const result = new StandardModelToSqlConverter().toSql(model) as Record<string, unknown>;
+
+      // managed FK comes from the relation, unmanaged FK is serialized as a column
+      expect(result).to.have.property('relation_id', 5);
+      expect(result).to.have.property('UserId', 42);
+    });
+
+    it('should throw when an unrelated NOT NULL FK column is null', () => {
+      const model = mockModel(
+        [column('Id', { PrimaryKey: true, Nullable: false }), column('UserId', { IsForeignKey: true, Nullable: false })],
+        [],
+        { Id: 1, UserId: null },
+      );
+
+      expect(() => new StandardModelToSqlConverter().toSql(model)).to.throw(OrmException, /UserId/);
+    });
+
+    it('should still skip virtual columns', () => {
+      const model = mockModel(
+        [column('Id', { PrimaryKey: true, Nullable: false }), column('Computed', { Virtual: true })],
+        [],
+        { Id: 1, Computed: 'should-be-ignored' },
+      );
+
+      const result = new StandardModelToSqlConverter().toSql(model) as Record<string, unknown>;
+
+      expect(result).to.not.have.property('Computed');
+    });
   });
 });

--- a/packages/rbac-http-admin/src/controllers/Users/Profile.ts
+++ b/packages/rbac-http-admin/src/controllers/Users/Profile.ts
@@ -12,7 +12,7 @@ import { AuthorizedPolicy, Permission, Resource } from "@spinajs/rbac-http";
 @BasePath('users/profile')
 @Policy(AuthorizedPolicy)
 @Resource('users')
-export class Roles extends BaseController {
+export class Profile extends BaseController {
 
 
     @AutoinjectService('user.profile')

--- a/packages/rbac-http-admin/src/controllers/Users/Roles.ts
+++ b/packages/rbac-http-admin/src/controllers/Users/Roles.ts
@@ -12,7 +12,7 @@ import { Schema } from '@spinajs/validation';
     },
     required: ['role'],
 })
-export class RoleDto {
+class RoleDto {
     public role: string;
 
     constructor(data: Partial<RoleDto>) {


### PR DESCRIPTION
…ed FK columns

- join callback conditions now emit in the JOIN ON clause instead of the main WHERE, so a LEFT JOIN is no longer silently narrowed to an inner join
- serialize FK columns that have no backing relation (e.g. plain owner-id), fixing INSERTs that broke NOT NULL constraints
- rename Profile/RoleDto controller classes to match their purpose