### PR TITLE
status types, result type & jModel.Result err. inner

### DIFF
--- a/packages/queue-http-progress/src/controllers/JobsControllers.ts
+++ b/packages/queue-http-progress/src/controllers/JobsControllers.ts
@@ -9,12 +9,11 @@ export class JobsController extends BaseController {
     public async getStatus(@Param('jobId') jobId: string): Promise<Ok> {
         const row = await JobModel.select().where('JobId', jobId).firstOrFail();
         
-        const ctx = row.Result ?? {};
         const response: IJobStatusResponse = {
             jobId: row.JobId,
             progress: row.Progress,
             status: row.Status,
-            message: (ctx as any)?.Result,
+            result: row.Result as string,
             createdAt: row.CreatedAt,
         };
 

--- a/packages/queue-http-progress/src/models/JobEntry.ts
+++ b/packages/queue-http-progress/src/models/JobEntry.ts
@@ -3,7 +3,7 @@
 export interface IJobStatusResponse {
     jobId: string;
     progress: number; // 0-100
-    status: 'error' | 'success' | 'created' | 'executing';
-    message?: string;
+    status: 'error' | 'success' | 'created' | 'executing' | 'retrying' | 'dead';
+    result: string;
     createdAt: DateTime;
 }

--- a/packages/queue/src/index.ts
+++ b/packages/queue/src/index.ts
@@ -146,6 +146,7 @@ export class DefaultQueueService extends QueueService {
                 jModel.Status = jModel.Attempt > maxRetries ? 'dead' : 'retrying';
                 jModel.Result = {
                   message: err.message,
+                  ...(err.inner !== undefined && err.inner !== null && { errors: err.inner }),
                 };
 
                 await jModel.update();


### PR DESCRIPTION
Dostosowanie do nowych typów które dodał @bemon dla queue + obsługa bardziej złożonych błędów jak np. walidacja do result w przypadku odrzucenia / przerwania joba