### PR TITLE
fix(rbac): fix security, correctness bugs and add test coverage

### DIFF
--- a/packages/fs/src/local-provider.ts
+++ b/packages/fs/src/local-provider.ts
@@ -1,7 +1,6 @@
 /* eslint-disable security/detect-non-literal-fs-filename */
 import { IOFail } from '@spinajs/exceptions';
 import { constants, createReadStream, createWriteStream, existsSync, readFileSync, Stats } from 'fs';
-import { tmpdir } from 'os';
 import { rm, stat, readdir, rename, mkdir, access, open, appendFile, readFile } from 'node:fs/promises';
 import { DateTime } from 'luxon';
 import { DI, Injectable, PerInstanceCheck } from '@spinajs/di';

--- a/packages/orm/src/builders.ts
+++ b/packages/orm/src/builders.ts
@@ -1359,6 +1359,11 @@ export class DeleteQueryBuilder<T> extends QueryBuilder<IUpdateResult> {
     };
 
     this.QueryContext = QueryContext.Delete;
+
+    // Query middlewares (e.g. rbac ownership enforcement) must run for deletes
+    // too, not only selects — otherwise :own permission constraints are never
+    // applied and any row can be deleted.
+    this._queryMiddlewares.forEach((x) => x.afterQueryCreation(this));
   }
 
   public toDB(): ICompilerOutput {
@@ -1439,6 +1444,11 @@ export class UpdateQueryBuilder<T> extends QueryBuilder<IUpdateResult> {
     this._statements = [];
 
     this.QueryContext = QueryContext.Update;
+
+    // Query middlewares (e.g. rbac ownership enforcement) must run for updates
+    // too, not only selects — otherwise :own permission constraints are never
+    // applied and any row can be updated.
+    this._queryMiddlewares.forEach((x) => x.afterQueryCreation(this));
   }
 
   public in(name: string) {

--- a/packages/queue/src/migrations/Queue_2026_07_17_00_00_00.ts
+++ b/packages/queue/src/migrations/Queue_2026_07_17_00_00_00.ts
@@ -14,6 +14,14 @@ import { OrmMigration, OrmDriver, Migration } from '@spinajs/orm';
 @Migration('queue')
 export class Queue_2026_07_17_00_00_00 extends OrmMigration {
   public async up(connection: OrmDriver): Promise<void> {
+    // sqlite stores enum as unconstrained TEXT and cannot MODIFY a column, so
+    // there is nothing to widen (see class doc). Guarding here keeps the sqlite
+    // alteration a true no-op instead of emitting an unsupported `MODIFY` and
+    // failing at runtime.
+    if ((connection.Options?.Driver ?? '').includes('sqlite')) {
+      return;
+    }
+
     await connection.schema().alterTable('queue_jobs', (table) => {
       // `.default().value('created')` returns the ColumnQueryBuilder, which has no
       // `.modify()` - that lives on AlterColumnQueryBuilder. So `.modify()` must be

--- a/packages/rbac-http-admin/src/controllers/Users/Users.ts
+++ b/packages/rbac-http-admin/src/controllers/Users/Users.ts
@@ -257,8 +257,12 @@ export class Users extends BaseController {
   ) {
 
     const temporaryPassword = this.PasswordProvider.generate();
-    const u = await create(data.Email, data.Login, temporaryPassword, [data.Role], undefined, data.Metadata);
-    return new Ok(u);
+    const { User: created } = await create(data.Email, data.Login, temporaryPassword, [data.Role], undefined, data.Metadata);
+
+    // NOTE: create() returns { User, Password } where Password is the plaintext
+    // temporary password. It must NOT be sent in the response — return only the
+    // created user (dehydrated, so the hash and internal id stay hidden too).
+    return new Ok(created.dehydrateWithRelations({ dateTimeFormat: 'iso' }));
   }
 
 

--- a/packages/rbac-http-user/src/controllers/TwoFactorAuthController.ts
+++ b/packages/rbac-http-user/src/controllers/TwoFactorAuthController.ts
@@ -102,15 +102,18 @@ export class TwoFactorAuthController extends BaseController {
             });
 
 
-            const grants = this.AC.getGrants();
-            const userGrants = logged.Role.map(r => _unwindGrants(r, grants));
-            const combinedGrants = Object.assign({}, ...userGrants);
-
+            // Mirror the login response shape: resolve grants for the session's
+            // active role (falling back to the first role) and include ActiveRole,
+            // instead of flattening every role with no ActiveRole reported.
+            const activeRole = (session.Data.get('ActiveRole') as string | undefined) ?? logged.Role?.[0];
+            const combinedGrants = activeRole ? _unwindGrants(activeRole, this.AC.getGrants()) : {};
 
             return new Ok({
                 ...logged.dehydrateWithRelations({
                     dateTimeFormat: "iso"
                 }),
+                Role: logged.Role,
+                ActiveRole: activeRole,
                 Grants: combinedGrants,
             } as unknown as IUserWithGrants);
         }

--- a/packages/rbac-http-user/src/controllers/UserController.ts
+++ b/packages/rbac-http-user/src/controllers/UserController.ts
@@ -54,7 +54,11 @@ export class UserController extends BaseController {
     if (sId) {
       const session = await this.SessionProvider.restore(sId);
       if (session) {
-        session.Data.set('User', user.dehydrate());
+        // Session stores the user UUID (see LoginController) — RbacUserFactory
+        // resolves the user from it on each request. Storing a dehydrated object
+        // here would break that lookup and log the user out on the next request.
+        session.Data.set('User', user.Uuid);
+        await this.SessionProvider.save(session);
       }
     }
 

--- a/packages/rbac-http-user/src/controllers/UserMetadataController.ts
+++ b/packages/rbac-http-user/src/controllers/UserMetadataController.ts
@@ -1,6 +1,6 @@
 import { Post, BasePath, Ok, Del, Body, Get, Query, Param, Policy, BaseController, Patch } from '@spinajs/http';
 import { User as UserModel, UserMetadata } from '@spinajs/rbac';
-import { AuthorizedPolicy, Permission, Resource } from '@spinajs/rbac-http';
+import { AuthorizedPolicy, Permission, Resource, User } from '@spinajs/rbac-http';
 import { AsModel, PaginationDTO, OrderDTO, Filter, IFilterRequest, FromModel } from '@spinajs/orm-http';
 import { UserMetadataDto } from '../dto/metadata-dto.js';
 import { InsertBehaviour, SortOrder } from '@spinajs/orm';
@@ -181,12 +181,17 @@ export class UserMetadataController extends BaseController {
     @Get("metadata")
     @Permission(['readOwn'])
     public async readMeta(
+        @User() user: UserModel,
         @Query() pagination?: PaginationDTO,
         @Query() order?: OrderDTO,
         @Filter(FilterableUserMetadata)
         filter?: IFilterRequest,
     ) {
-        return new Ok(FilterableUserMetadata.select().filter(filter?.filters ?? [], filter?.op)
+        // Explicit owner scoping: the rbac query middleware does not enforce
+        // ownership for the metadata model (queries resolve to the unsafe base
+        // model without an @OrmResource), so every own-route filters by the
+        // authenticated user's id directly.
+        return new Ok(FilterableUserMetadata.select().where('user_id', user.Id).filter(filter?.filters ?? [], filter?.op)
             .take(pagination?.limit ?? 0)
             .skip((pagination?.limit ?? 0) * (pagination?.page ?? 0))
             .order(order?.column ?? 'Id', order?.order ?? SortOrder.DESC)
@@ -205,9 +210,10 @@ export class UserMetadataController extends BaseController {
      */
     @Get("metadata/:key")
     @Permission(['readOwn'])
-    public async getMeta(@Param() key: string) {
+    public async getMeta(@User() user: UserModel, @Param() key: string) {
         return new Ok(UserMetadata.where({
             Key: key,
+            user_id: user.Id,
         }).firstOrFail());
     }
 
@@ -221,8 +227,12 @@ export class UserMetadataController extends BaseController {
      */
     @Post("metadata")
     @Permission(['updateOwn'])
-    public async addMetadata(@AsModel() metadata: UserMetadata) {
+    public async addMetadata(@User() user: UserModel, @AsModel() metadata: UserMetadata) {
+        // force ownership to the authenticated user — never trust a user_id
+        // supplied in the request body
+        metadata.user_id = user.Id;
         await metadata.insert(InsertBehaviour.InsertOrUpdate);
+        return new Ok();
     }
 
     /**
@@ -238,12 +248,20 @@ export class UserMetadataController extends BaseController {
      */
     @Patch('metadata/:meta')
     @Permission(['updateOwn'])
-    public async updateMetadata(@Param() meta: string, @Body() data: UserMetadataDto) {
+    public async updateMetadata(@User() user: UserModel, @Param() meta: string, @Body() data: UserMetadataDto) {
+        // The Key/Id lookup is grouped and AND-ed with an explicit ownership
+        // filter. Without the grouping the flat "Key = ? OR Id = ? AND user_id = ?"
+        // binds as "Key = ? OR (Id = ? AND user_id = ?)", letting any user update
+        // another user's metadata by its Key. Scoping by user_id explicitly (not
+        // relying on the query middleware, which does not fire for this model)
+        // keeps the update owner-bound.
         await UserMetadata.update({
             Key: data.Key,
             Value: data.Value,
             Type: data.Type
-        }).where("Key", meta).orWhere("Id", meta);
+        }).where(function () {
+            this.where("Key", meta).orWhere("Id", meta);
+        }).andWhere('user_id', user.Id);
 
         return new Ok();
     }
@@ -260,9 +278,10 @@ export class UserMetadataController extends BaseController {
      */
     @Del('metadata/:meta')
     @Permission(['deleteOwn'])
-    public async deleteMetadata(@Param() meta: number) {
+    public async deleteMetadata(@User() user: UserModel, @Param() meta: number) {
         await UserMetadata.destroy().where({
-            Id: meta
+            Id: meta,
+            user_id: user.Id,
         });
 
         return new Ok();

--- a/packages/rbac-http-user/test/z-controller-refresh.test.ts
+++ b/packages/rbac-http-user/test/z-controller-refresh.test.ts
@@ -1,0 +1,89 @@
+// Pure unit test: the controller is constructed directly and its injected
+// fields are set by hand, so it does NOT touch the process-wide DI container
+// that sibling suites contaminate (they alias UserController / register other
+// providers without cleanup).
+import 'mocha';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import * as cs from 'cookie-signature';
+
+import { ISession, UserSession } from '@spinajs/rbac';
+import { UserController } from '../src/controllers/UserController.js';
+
+const COOKIE_SECRET = 'unit-test-secret';
+
+class FakeSessionProvider {
+  public Store = new Map<string, ISession>();
+  public SavedCount = 0;
+
+  public async restore(id: string): Promise<ISession | null> {
+    return this.Store.get(id) ?? null;
+  }
+  public async save(idOrSession: ISession | string): Promise<void> {
+    this.SavedCount++;
+    if (typeof idOrSession !== 'string') {
+      this.Store.set(idOrSession.SessionId, idOrSession);
+    }
+  }
+}
+
+describe('UserController.refresh', function () {
+  this.timeout(15000);
+
+  let controller: UserController;
+  let sessionProvider: FakeSessionProvider;
+
+  beforeEach(() => {
+    controller = new UserController();
+    sessionProvider = new FakeSessionProvider();
+
+    // @Config / @Autoinject make these getter-only; override via defineProperty
+    Object.defineProperty(controller, 'CoockieSecret', { value: COOKIE_SECRET, configurable: true, writable: true });
+    Object.defineProperty(controller, 'SessionProvider', { value: sessionProvider, configurable: true, writable: true });
+  });
+
+  afterEach(() => sinon.restore());
+
+  it('stores the user UUID (not a dehydrated object) back into the session', async () => {
+    const session = new UserSession();
+    session.Data.set('User', 'stale-value');
+    sessionProvider.Store.set(session.SessionId, session);
+
+    const signedSsid = cs.sign(session.SessionId, COOKIE_SECRET);
+
+    const user: any = {
+      Uuid: 'user-uuid-123',
+      refresh: sinon.stub().resolves(),
+      Metadata: { populate: sinon.stub().resolves() },
+      dehydrate: () => ({ Uuid: 'user-uuid-123', Login: 'bob' }),
+    };
+
+    await controller.refresh(user, signedSsid);
+
+    // must be the plain UUID string so RbacUserFactory can resolve the user
+    // on subsequent requests (storing a dehydrated object silently logs the
+    // user out on the next request).
+    expect(session.Data.get('User')).to.equal('user-uuid-123');
+    expect(typeof session.Data.get('User')).to.equal('string');
+    expect(sessionProvider.SavedCount).to.be.greaterThan(0);
+  });
+
+  it('does not touch the session when the cookie signature is invalid', async () => {
+    const session = new UserSession();
+    session.Data.set('User', 'original');
+    sessionProvider.Store.set(session.SessionId, session);
+
+    const user: any = {
+      Uuid: 'user-uuid-123',
+      refresh: sinon.stub().resolves(),
+      Metadata: { populate: sinon.stub().resolves() },
+      dehydrate: () => ({ Uuid: 'user-uuid-123' }),
+    };
+
+    // ssid not signed with our secret -> cs.unsign returns false
+    await controller.refresh(user, 'not-a-valid-signed-cookie');
+
+    expect(session.Data.get('User')).to.equal('original');
+    expect(sessionProvider.SavedCount).to.equal(0);
+  });
+});

--- a/packages/rbac/src/actions.ts
+++ b/packages/rbac/src/actions.ts
@@ -6,7 +6,8 @@ import { _ev } from '@spinajs/queue';
 import { USER_COMMON_METADATA, User, UserBase } from './models/User.js';
 import { _cfg, _service } from '@spinajs/configuration';
 import { UserActivated, UserBanned, UserChanged, UserCreated, UserDeactivated, UserDeleted, UserLogged, UserPasswordChangeRequest, UserPasswordChanged, UserRoleGranted, UserRoleRevoked, UserUnbanned } from './events/index.js';
-import { Constructor } from '@spinajs/di';
+import { Constructor, DI } from '@spinajs/di';
+import { Configuration } from '@spinajs/configuration';
 import { UserEvent } from './events/UserEvent.js';
 import { AuthProvider, PasswordProvider, PasswordValidationProvider } from './interfaces.js';
 import { DateTime } from 'luxon';
@@ -285,6 +286,21 @@ export async function deactivate(identifier: number | string | User): Promise<vo
 export type CreateMiddleware = (u: User) => Promise<User> | User;
 
 /**
+ * Reads a create-middleware list from configuration.
+ *
+ * NOTE: we deliberately do NOT use `_cfg(path, [])` here. `_cfg` wraps its
+ * result in `_non_nil()`, which rejects empty arrays — so an unset or
+ * empty `beforeCreate` / `afterCreate` (the default in the shipped config)
+ * would throw and break user creation. Reading the value directly keeps an
+ * empty list as a valid "no middleware" result.
+ */
+function _create_middleware(path: string): CreateMiddleware[] {
+  const cfg = DI.get(Configuration);
+  const mw = cfg?.get<CreateMiddleware[]>(path, []);
+  return Array.isArray(mw) ? mw : [];
+}
+
+/**
  * Creates a new user account.
  *
  * Validates and normalises inputs, hashes the password, inserts the user record,
@@ -329,11 +345,7 @@ export async function create(email: string, login: string, password: string, rol
       ),
 
     // run before create middleware
-    (u: User) =>
-      _chain(
-        _cfg<CreateMiddleware[]>('rbac.actions.create.beforeCreate', []),
-        (beforeCreate: CreateMiddleware[]) => _chain(u, ...beforeCreate)
-      ),
+    (u: User) => _chain(u, ..._create_middleware('rbac.actions.create.beforeCreate')),
 
     // insert to db
     _insert(),
@@ -343,11 +355,7 @@ export async function create(email: string, login: string, password: string, rol
       async (u: User) => u),
 
     // run after create middleware
-    (u: User) =>
-      _chain(
-        _cfg<CreateMiddleware[]>('rbac.actions.create.afterCreate', []),
-        (afterCreate: CreateMiddleware[]) => _chain(u, ...afterCreate)
-      ),
+    (u: User) => _chain(u, ..._create_middleware('rbac.actions.create.afterCreate')),
 
     // send event
     _user_ev(UserCreated, (u: User) => u.toJSON()),
@@ -458,12 +466,23 @@ export async function ban(identifier: number | string | User, reason?: string, d
 export async function unban(identifier: number | string | User): Promise<User> {
   return _chain(
     _user(identifier),
-    (u: User) => {
+
+    // guard must return the user so the chain can keep flowing it downstream
+    _tap(async (u: User) => {
       if (!u.Metadata[USER_COMMON_METADATA.USER_BAN_IS_BANNED]) {
         throw new ErrorCode(E_CODES.E_USER_BANNED, `User is already unbanned`, { user: u });
       }
-    },
-    _set_user_meta('/^user:ban/', null),
+    }),
+
+    // actually remove the ban metadata from the DB. Assigning a regex-like
+    // string key never cleared anything; delete() removes each key from store.
+    _tap(async (u: User) => {
+      await u.Metadata.delete(USER_COMMON_METADATA.USER_BAN_IS_BANNED);
+      await u.Metadata.delete(USER_COMMON_METADATA.USER_BAN_START_DATE);
+      await u.Metadata.delete(USER_COMMON_METADATA.USER_BAN_DURATION);
+      await u.Metadata.delete(USER_COMMON_METADATA.USER_BAN_REASON);
+    }),
+
     _user_ev(UserUnbanned),
   );
 }
@@ -476,7 +495,7 @@ export async function unban(identifier: number | string | User): Promise<User> {
  * @param identifier - numeric id, uuid / email / login string, or an existing {@link User} instance
  */
 export async function passwordChangeRequest(identifier: number | string | User) {
-  const pwdWaitTime = await _cfg<number>('rbac.password.reset_wait_time')();
+  const pwdWaitTime = await _cfg<number>('rbac.password.passwordResetWaitTime')();
 
   return _chain(
     _user(identifier),
@@ -502,7 +521,7 @@ export async function confirmPasswordReset(identifier: number | string | User, n
     _user(identifier),
     _tap((u: User) =>
       _chain(u, _zip(_get_user_meta(USER_COMMON_METADATA.USER_PWD_RESET_START_DATE), _get_user_meta(USER_COMMON_METADATA.USER_PWD_RESET_WAIT_TIME)), ([dueDate, waitTime]: [DateTime, number]) => {
-        if (dueDate.plus(waitTime) < DateTime.now()) {
+        if (dueDate.plus({ seconds: waitTime }) < DateTime.now()) {
           throw new ErrorCode(E_CODES.E_TOKEN_EXPIRED, `Password change token expired, token expiration date is: ${dueDate.toISO()}`, {
             dueDate,
             waitTime,

--- a/packages/rbac/src/cli/ActivateUser.ts
+++ b/packages/rbac/src/cli/ActivateUser.ts
@@ -11,7 +11,7 @@ export class ActivateUser extends CliCommand {
 
   public async execute(idOrUuid: string, active: boolean): Promise<void> {
     try {
-      (await active) ? activate(idOrUuid) : deactivate(idOrUuid);
+      await (active ? activate(idOrUuid) : deactivate(idOrUuid));
 
       this.Log.success(`User ${idOrUuid} ${active ? 'activated' : 'deactivated'}`);
     } catch (e) {

--- a/packages/rbac/src/cli/BanUser.ts
+++ b/packages/rbac/src/cli/BanUser.ts
@@ -13,7 +13,7 @@ export class BanUser extends CliCommand {
 
   public async execute(idOrUuid: string, banOrUnban: boolean, duration: number, reason: string): Promise<void> {
     try {
-      (await banOrUnban) ? ban(idOrUuid, reason, duration) : unban(idOrUuid);
+      await (banOrUnban ? ban(idOrUuid, reason, duration) : unban(idOrUuid));
 
       this.Log.success(`User ${idOrUuid} ${banOrUnban ? 'banned' : 'unbanned'}`);
     } catch (e: any) {

--- a/packages/rbac/src/cron/DeactivatePasswords.ts
+++ b/packages/rbac/src/cron/DeactivatePasswords.ts
@@ -4,7 +4,11 @@ import {  CliCommand, Command } from '@spinajs/cli';
 import { Autoinject } from '@spinajs/di';
 import { activate, deactivate } from '../actions.js';
 
-@Command('rbac:user-activate', 'Sets active or inactive user')
+// NOTE: this file is an orphaned copy of cli/ActivateUser.ts — it is not in the
+// registered `cli` dir and is imported nowhere. Its command id used to collide
+// with cli/ActivateUser (`rbac:user-activate`); renamed here to avoid a
+// duplicate-command registration if the folder is ever loaded. Consider deleting.
+@Command('rbac:user-activate-cron', 'Sets active or inactive user')
 export class DeactivatePassowords extends CliCommand {
   @Logger('rbac')
   protected Log: Log;
@@ -14,7 +18,7 @@ export class DeactivatePassowords extends CliCommand {
 
   public async execute(idOrUuid: string, active: boolean): Promise<void> {
     try {
-      await active ? activate(idOrUuid) : deactivate(idOrUuid);
+      await (active ? activate(idOrUuid) : deactivate(idOrUuid));
 
       this.Log.success(`User ${idOrUuid} ${active ? 'activated' : 'deactivated'}`);
     } catch (e) {

--- a/packages/rbac/src/index.ts
+++ b/packages/rbac/src/index.ts
@@ -8,6 +8,7 @@ import { Log } from '@spinajs/log';
 import './auth.js';
 import './password.js';
 import './session.js';
+import './ownership.js';
 import { User } from './models/User.js';
 
 export * from './interfaces.js';
@@ -24,6 +25,7 @@ export * from './decorators.js';
 export * from './util.js';
 export * from './profile.js';
 export * from './impersonation.js';
+export * from './ownership.js';
 
 // fix error `The requested module 'accesscontrol' is a CommonJS module`
 const { Permission } = ac;

--- a/packages/rbac/src/models/User.ts
+++ b/packages/rbac/src/models/User.ts
@@ -261,7 +261,25 @@ export class UserBase extends ModelBase<UserBase> {
   }
 
   public get IsBanned(): boolean {
-    return this.Metadata[USER_COMMON_METADATA.USER_BAN_IS_BANNED] === true;
+    if (this.Metadata[USER_COMMON_METADATA.USER_BAN_IS_BANNED] !== true) {
+      return false;
+    }
+
+    const start = this.Metadata[USER_COMMON_METADATA.USER_BAN_START_DATE];
+    const duration = this.Metadata[USER_COMMON_METADATA.USER_BAN_DURATION];
+
+    // no start/duration recorded -> treat as a permanent ban
+    if (!start || duration === null || duration === undefined) {
+      return true;
+    }
+
+    const startDt = start instanceof DateTime ? start : DateTime.fromISO(String(start));
+    if (!startDt.isValid) {
+      return true;
+    }
+
+    // ban is still active only until start + duration (seconds) elapses
+    return startDt.plus({ seconds: Number(duration) }) > DateTime.now();
   }
 
   public dehydrateWithRelations(options?: IDehydrateOptions): ModelDataWithRelationData<this> {

--- a/packages/rbac/src/ownership.ts
+++ b/packages/rbac/src/ownership.ts
@@ -1,0 +1,60 @@
+import { ModelBase, OrmException, extractModelDescriptor, IDeleteQueryBuilder, IQueryBuilder, ISelectQueryBuilder, IUpdateQueryBuilder } from '@spinajs/orm';
+import { IRbacModelDescriptor } from './interfaces.js';
+import type { User } from './models/User.js';
+
+/**
+ * Implementation of the ownership helpers declared on `IModelStatic` in
+ * `interfaces.ts`. They were previously declared but never implemented, so any
+ * call to `Model.ensureOwnership` / `Model.checkOwnership` threw
+ * "not a function". They are attached to `ModelBase` so every model gets them.
+ *
+ * A model participates in ownership checks by decorating its owner column with
+ * `@ResourceOwner()`, which sets `OwnerField` on the model descriptor.
+ */
+
+function rbacDescriptor(model: unknown): IRbacModelDescriptor {
+  const descriptor = extractModelDescriptor(model as any) as IRbacModelDescriptor;
+
+  if (!descriptor || !descriptor.OwnerField) {
+    const name = descriptor?.Name ?? (model as any)?.name;
+    throw new OrmException(`Model ${name} does not have an @ResourceOwner() field, cannot check ownership`);
+  }
+
+  return descriptor;
+}
+
+/**
+ * Alters a query so it only returns/updates/deletes rows owned by `user`.
+ */
+(ModelBase as unknown as { ensureOwnership: unknown }).ensureOwnership = function (
+  this: unknown,
+  query: ISelectQueryBuilder<any> | IUpdateQueryBuilder<any> | IDeleteQueryBuilder<any>,
+  user: User,
+): IQueryBuilder {
+  const descriptor = rbacDescriptor(this);
+  return (query as any).where(descriptor.OwnerField, user.PrimaryKeyValue);
+};
+
+/**
+ * Checks whether a model (or its primary key) is owned by `user`.
+ * When passed a loaded model the owner column is compared in memory; when
+ * passed a primary key the ownership is verified with a scoped DB query.
+ */
+(ModelBase as unknown as { checkOwnership: unknown }).checkOwnership = async function (
+  this: unknown,
+  modelOrPrimaryKey: ModelBase<any> | string | number,
+  user: User,
+): Promise<boolean> {
+  const descriptor = rbacDescriptor(this);
+
+  if (modelOrPrimaryKey instanceof ModelBase) {
+    return (modelOrPrimaryKey as any)[descriptor.OwnerField] === user.PrimaryKeyValue;
+  }
+
+  const found = await (this as any)
+    .where(descriptor.PrimaryKey, modelOrPrimaryKey)
+    .where(descriptor.OwnerField, user.PrimaryKeyValue)
+    .first();
+
+  return found !== undefined && found !== null;
+};

--- a/packages/rbac/test/actions.test.ts
+++ b/packages/rbac/test/actions.test.ts
@@ -2,7 +2,7 @@ import { BasicPasswordProvider } from '../src/password.js';
 import { Bootstrapper, DI } from '@spinajs/di';
 import chaiAsPromised from 'chai-as-promised';
 import * as chai from 'chai';
-import { PasswordProvider, SimpleDbAuthProvider, AuthProvider, User, UserActivated, UserChanged, deactivate, UserDeactivated, create, UserCreated, deleteUser, UserDeleted, ban, USER_COMMON_METADATA, login, UserLogged, UserBanned, CreateMiddleware } from '../src/index.js';
+import { PasswordProvider, SimpleDbAuthProvider, AuthProvider, User, UserActivated, UserChanged, deactivate, UserDeactivated, create, UserCreated, deleteUser, UserDeleted, ban, unban, grant, revoke, changePassword, _user_update, passwordChangeRequest, confirmPasswordReset, USER_COMMON_METADATA, login, UserLogged, UserBanned, UserUnbanned, UserPasswordChanged, UserPasswordChangeRequest, CreateMiddleware } from '../src/index.js';
 import { Configuration } from '@spinajs/configuration';
 import { SqliteOrmDriver } from '@spinajs/orm-sqlite';
 import { Orm } from '@spinajs/orm';
@@ -53,7 +53,7 @@ describe('User model tests', function () {
   });
 
   it('Should activate user', async () => {
-    const eStub = sinon.stub(DefaultQueueService.prototype, 'emit').returns(Promise.resolve());
+    const eStub = sinon.stub(DefaultQueueService.prototype, 'emit').returns(Promise.resolve(undefined));
 
     let user = await User.query().whereAnything('test-notactive@spinajs.pl').firstOrFail();
 
@@ -74,7 +74,7 @@ describe('User model tests', function () {
   });
 
   it('Should deactivate user', async () => {
-    const eStub = sinon.stub(DefaultQueueService.prototype, 'emit').returns(Promise.resolve());
+    const eStub = sinon.stub(DefaultQueueService.prototype, 'emit').returns(Promise.resolve(undefined));
 
     let user = await User.query().whereAnything('test@spinajs.pl').firstOrFail();
     expect(user.IsActive).to.eq(true);
@@ -89,7 +89,7 @@ describe('User model tests', function () {
   });
 
   it('Should create user', async () => {
-    const eStub = sinon.stub(DefaultQueueService.prototype, 'emit').returns(Promise.resolve());
+    const eStub = sinon.stub(DefaultQueueService.prototype, 'emit').returns(Promise.resolve(undefined));
 
     const { User: U, Password } = await create('test@wp.pl', 'test222', 'bbbb', ['admin']);
 
@@ -110,7 +110,7 @@ describe('User model tests', function () {
   });
 
   it('Should create user with metadata', async () => {
-    const eStub = sinon.stub(DefaultQueueService.prototype, 'emit').returns(Promise.resolve());
+    const eStub = sinon.stub(DefaultQueueService.prototype, 'emit').returns(Promise.resolve(undefined));
 
     const { User: U, Password } = await create('meta@wp.pl', 'metameta', 'bbbb', ['admin'], undefined, {
       'user:niceName': 'Meta User',
@@ -138,7 +138,7 @@ describe('User model tests', function () {
   });
 
   it('Should create user with beforeCreate and afterCreate middleware', async () => {
-    sinon.stub(DefaultQueueService.prototype, 'emit').returns(Promise.resolve());
+    sinon.stub(DefaultQueueService.prototype, 'emit').returns(Promise.resolve(undefined));
 
     const beforeSpy = sinon.spy((u: User) => {
       u.IsActive = true;
@@ -184,7 +184,7 @@ describe('User model tests', function () {
   });
 
   it('Should delete user', async () => {
-    const eStub = sinon.stub(DefaultQueueService.prototype, 'emit').returns(Promise.resolve());
+    const eStub = sinon.stub(DefaultQueueService.prototype, 'emit').returns(Promise.resolve(undefined));
 
     let user = await User.query().whereAnything('test@spinajs.pl').firstOrFail();
 
@@ -203,7 +203,7 @@ describe('User model tests', function () {
   });
 
   it('Should ban user', async () => {
-    const eStub = sinon.stub(DefaultQueueService.prototype, 'emit').returns(Promise.resolve());
+    const eStub = sinon.stub(DefaultQueueService.prototype, 'emit').returns(Promise.resolve(undefined));
 
     await ban('test@spinajs.pl', 'Banned by admin', 100);
 
@@ -224,18 +224,116 @@ describe('User model tests', function () {
     expect((eStub.args[2] as any)[0]).to.be.instanceOf(EmailSend);
   });
 
-  it('Should unban user', async () => {});
+  it('Should unban user', async () => {
+    const eStub = sinon.stub(DefaultQueueService.prototype, 'emit').returns(Promise.resolve(undefined));
 
-  it('Should change password', async () => {});
+    await ban('test@spinajs.pl', 'Banned by admin', 100);
 
-  it('Should grant role', async () => {});
+    let user = await User.query().whereAnything('test@spinajs.pl').populate('Metadata').firstOrFail();
+    expect(user.IsBanned).to.be.true;
 
-  it('Should revoke role', async () => {});
+    eStub.resetHistory();
 
-  it('Should update user', async () => {});
+    await unban('test@spinajs.pl');
+
+    user = await User.query().whereAnything('test@spinajs.pl').populate('Metadata').firstOrFail();
+
+    // ban must actually be lifted, not just an in-memory no-op
+    expect(user.IsBanned).to.be.false;
+    expect(user.Metadata[USER_COMMON_METADATA.USER_BAN_IS_BANNED]).to.be.null;
+    expect(user.Metadata[USER_COMMON_METADATA.USER_BAN_REASON]).to.be.null;
+    expect(user.Metadata[USER_COMMON_METADATA.USER_BAN_DURATION]).to.be.null;
+    expect(user.Metadata[USER_COMMON_METADATA.USER_BAN_START_DATE]).to.be.null;
+
+    // UserUnbanned event emitted
+    expect(eStub.args.some((a) => (a as any)[0] instanceof UserUnbanned)).to.be.true;
+  });
+
+  it('Should not unban a user that is not banned', async () => {
+    sinon.stub(DefaultQueueService.prototype, 'emit').returns(Promise.resolve(undefined));
+    await expect(unban('test-notactive@spinajs.pl')).to.be.rejected;
+  });
+
+  it('Should treat a ban as expired once its duration elapses', async () => {
+    sinon.stub(DefaultQueueService.prototype, 'emit').returns(Promise.resolve(undefined));
+
+    await ban('test@spinajs.pl', 'temp', 100);
+
+    const user = await User.query().whereAnything('test@spinajs.pl').populate('Metadata').firstOrFail();
+    expect(user.IsBanned).to.be.true;
+
+    // move the ban start date to 200s ago while duration is 100s -> expired
+    user.Metadata[USER_COMMON_METADATA.USER_BAN_START_DATE] = DateTime.now().minus({ seconds: 200 });
+    await user.Metadata.update();
+
+    const reloaded = await User.query().whereAnything('test@spinajs.pl').populate('Metadata').firstOrFail();
+    expect(reloaded.IsBanned).to.be.false;
+  });
+
+  it('Should change password', async () => {
+    const eStub = sinon.stub(DefaultQueueService.prototype, 'emit').returns(Promise.resolve(undefined));
+
+    const user = await User.query().whereAnything('test@spinajs.pl').populate('Metadata').firstOrFail();
+    const oldHash = user.Password;
+
+    await changePassword('newPass123')(user);
+
+    const reloaded = await User.query().whereAnything('test@spinajs.pl').firstOrFail();
+    expect(reloaded.Password).to.not.eq(oldHash);
+
+    const pwd = await DI.resolve(BasicPasswordProvider);
+    expect(await pwd.verify(reloaded.Password, 'newPass123')).to.be.true;
+    expect(eStub.args.some((a) => (a as any)[0] instanceof UserPasswordChanged)).to.be.true;
+  });
+
+  it('Should reject a password that does not meet requirements', async () => {
+    sinon.stub(DefaultQueueService.prototype, 'emit').returns(Promise.resolve(undefined));
+    const user = await User.query().whereAnything('test@spinajs.pl').firstOrFail();
+    // password rule requires at least 8 chars with a letter and a digit
+    await expect(changePassword('short')(user)).to.be.rejected;
+  });
+
+  it('Should grant role', async () => {
+    sinon.stub(DefaultQueueService.prototype, 'emit').returns(Promise.resolve(undefined));
+
+    const before = await User.query().whereAnything('test@spinajs.pl').firstOrFail();
+    expect(before.Role).to.not.include('editor');
+
+    await grant('test@spinajs.pl', 'editor');
+
+    const after = await User.query().whereAnything('test@spinajs.pl').firstOrFail();
+    expect(after.Role).to.include('editor');
+
+    // granting the same role twice must not duplicate it
+    await grant('test@spinajs.pl', 'editor');
+    const again = await User.query().whereAnything('test@spinajs.pl').firstOrFail();
+    expect(again.Role.filter((r) => r === 'editor').length).to.eq(1);
+  });
+
+  it('Should revoke role', async () => {
+    sinon.stub(DefaultQueueService.prototype, 'emit').returns(Promise.resolve(undefined));
+
+    await grant('test@spinajs.pl', 'editor');
+    let user = await User.query().whereAnything('test@spinajs.pl').firstOrFail();
+    expect(user.Role).to.include('editor');
+
+    await revoke('test@spinajs.pl', 'editor');
+    user = await User.query().whereAnything('test@spinajs.pl').firstOrFail();
+    expect(user.Role).to.not.include('editor');
+  });
+
+  it('Should update user', async () => {
+    sinon.stub(DefaultQueueService.prototype, 'emit').returns(Promise.resolve(undefined));
+
+    const user = await User.query().whereAnything('test@spinajs.pl').firstOrFail();
+    await _user_update({ Login: 'updated-login' })(user);
+
+    const reloaded = await User.query().whereAnything('test@spinajs.pl').firstOrFail();
+    expect(reloaded.Login).to.eq('updated-login');
+  });
 
   it('Should authenticate user', async () => {
-    const eStub = sinon.stub(DefaultQueueService.prototype, 'emit').returns(Promise.resolve());
+    const eStub = sinon.stub(DefaultQueueService.prototype, 'emit').returns(Promise.resolve(undefined));
 
     const user = await login('test@spinajs.pl', 'bbbb');
 
@@ -245,7 +343,7 @@ describe('User model tests', function () {
   });
 
   it('Should not auth with invalid password', async () => {
-    const eStub = sinon.stub(DefaultQueueService.prototype, 'emit').returns(Promise.resolve());
+    const eStub = sinon.stub(DefaultQueueService.prototype, 'emit').returns(Promise.resolve(undefined));
 
     await expect(login('test@spinajs.pl', 'bbbbssss')).to.be.rejected;
     expect(eStub.callCount).to.eq(1);
@@ -259,7 +357,7 @@ describe('User model tests', function () {
 
   it('Should reject auth with banned user', async () => {
 
-    const eStub = sinon.stub(DefaultQueueService.prototype, 'emit').returns(Promise.resolve());
+    const eStub = sinon.stub(DefaultQueueService.prototype, 'emit').returns(Promise.resolve(undefined));
 
     await expect(login('test-banned@spinajs.pl', 'bbbb')).to.be.rejected;
     expect(eStub.callCount).to.eq(1);
@@ -267,7 +365,7 @@ describe('User model tests', function () {
   });
 
   it('Should reject auth with not active user', async () => {
-    const eStub = sinon.stub(DefaultQueueService.prototype, 'emit').returns(Promise.resolve());
+    const eStub = sinon.stub(DefaultQueueService.prototype, 'emit').returns(Promise.resolve(undefined));
 
     await expect(login('test-notactive@spinajs.pl', 'bbbb')).to.be.rejected;
     expect(eStub.callCount).to.eq(1);
@@ -275,11 +373,55 @@ describe('User model tests', function () {
   });
 
 
-  it('Password change request ', async () => {});
+  it('Password change request ', async () => {
+    const eStub = sinon.stub(DefaultQueueService.prototype, 'emit').returns(Promise.resolve(undefined));
 
-  it('Password change after request', async () => {});
+    await passwordChangeRequest('test@spinajs.pl');
 
-  it('Password change after request with wrong token', async () => {});
+    const user = await User.query().whereAnything('test@spinajs.pl').populate('Metadata').firstOrFail();
 
-  it('Password change after request with expired token', async () => {});
+    // a reset token, start date and wait time must be stored
+    expect(user.Metadata[USER_COMMON_METADATA.USER_PWD_RESET_TOKEN]).to.be.a('string');
+    expect(user.Metadata[USER_COMMON_METADATA.USER_PWD_RESET_START_DATE]).to.be.not.null;
+    // wait time must come from config (rbac.password.passwordResetWaitTime), not be undefined
+    expect(user.Metadata[USER_COMMON_METADATA.USER_PWD_RESET_WAIT_TIME]).to.eq(60 * 60);
+
+    expect(eStub.args.some((a) => (a as any)[0] instanceof UserPasswordChangeRequest)).to.be.true;
+  });
+
+  it('Password change after request', async () => {
+    sinon.stub(DefaultQueueService.prototype, 'emit').returns(Promise.resolve(undefined));
+
+    await passwordChangeRequest('test@spinajs.pl');
+    let user = await User.query().whereAnything('test@spinajs.pl').populate('Metadata').firstOrFail();
+    const token = user.Metadata[USER_COMMON_METADATA.USER_PWD_RESET_TOKEN];
+
+    await confirmPasswordReset('test@spinajs.pl', 'brandNew123', token);
+
+    user = await User.query().whereAnything('test@spinajs.pl').firstOrFail();
+    const pwd = await DI.resolve(BasicPasswordProvider);
+    expect(await pwd.verify(user.Password, 'brandNew123')).to.be.true;
+  });
+
+  it('Password change after request with wrong token', async () => {
+    sinon.stub(DefaultQueueService.prototype, 'emit').returns(Promise.resolve(undefined));
+
+    await passwordChangeRequest('test@spinajs.pl');
+
+    await expect(confirmPasswordReset('test@spinajs.pl', 'brandNew123', 'not-the-token')).to.be.rejected;
+  });
+
+  it('Password change after request with expired token', async () => {
+    sinon.stub(DefaultQueueService.prototype, 'emit').returns(Promise.resolve(undefined));
+
+    await passwordChangeRequest('test@spinajs.pl');
+    const user = await User.query().whereAnything('test@spinajs.pl').populate('Metadata').firstOrFail();
+    const token = user.Metadata[USER_COMMON_METADATA.USER_PWD_RESET_TOKEN];
+
+    // force the reset request to be older than the configured wait time
+    user.Metadata[USER_COMMON_METADATA.USER_PWD_RESET_START_DATE] = DateTime.now().minus({ seconds: 2 * 60 * 60 });
+    await user.Metadata.update();
+
+    await expect(confirmPasswordReset('test@spinajs.pl', 'brandNew123', token)).to.be.rejected;
+  });
 });

--- a/packages/rbac/test/auth.test.ts
+++ b/packages/rbac/test/auth.test.ts
@@ -1,5 +1,5 @@
 import { BasicPasswordProvider } from '../src/password.js';
-import { DI } from '@spinajs/di';
+import { Bootstrapper, DI } from '@spinajs/di';
 import chaiAsPromised from 'chai-as-promised';
 import * as chai from 'chai';
 import { PasswordProvider, SimpleDbAuthProvider, AuthProvider, User } from '../src/index.js';
@@ -26,6 +26,11 @@ describe('Authorization provider tests', () => {
   });
 
   beforeEach(async () => {
+    const bootstrappers = await DI.resolve(Array.ofType(Bootstrapper));
+    for (const b of bootstrappers) {
+      await b.bootstrap();
+    }
+
     await DI.resolve(Configuration, [null, null, [dir('./config')]]);
     await DI.resolve(Orm);
   });

--- a/packages/rbac/test/common.test.ts
+++ b/packages/rbac/test/common.test.ts
@@ -136,8 +136,8 @@ export class TestConfiguration extends FrameworkConfiguration {
               // UNCOMMENT ONE OF BELOW OR MODIFY
               // VALIDATION RULE IS JSON SCHEMA
 
-              // Minimum eight characters, at least one letter and one number
-              pattern: '^(?=.*[A-Za-z])(?=.*d)[A-Za-zd]{8,}$',
+              // Minimum eight characters, at least one number
+              pattern: '^(?=.*\\d).{8,}$',
 
               // Minimum eight characters, at least one letter, one number and one special character:
               // pattern: '^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]{8,}$',

--- a/packages/rbac/test/migration/rbac.migration.ts
+++ b/packages/rbac/test/migration/rbac.migration.ts
@@ -13,9 +13,10 @@ export const TEST_USER_UUID_3 = uuidv4();
 export class RbacMigration_2022_06_28_01_13_00 extends OrmMigration {
   public async up(connection: OrmDriver<IDriverOptions>): Promise<void> {
 
-    await connection.schema().createTable('test', (table) =>{ 
+    await connection.schema().createTable('test', (table) =>{
       table.int('Id').primaryKey().autoIncrement();
       table.int('UserId');
+      table.string('Value');
     });
   }
 

--- a/packages/rbac/test/models/ResourceModel.ts
+++ b/packages/rbac/test/models/ResourceModel.ts
@@ -12,4 +12,6 @@ export class ResourceModel extends ModelBase {
     @ResourceOwner()
     public UserId : number;
 
+    public Value: string;
+
 }

--- a/packages/rbac/test/ownership.test.ts
+++ b/packages/rbac/test/ownership.test.ts
@@ -1,0 +1,91 @@
+import { BasicPasswordProvider } from '../src/password.js';
+import { Bootstrapper, DI } from '@spinajs/di';
+import chaiAsPromised from 'chai-as-promised';
+import * as chai from 'chai';
+import { expect } from 'chai';
+import { PasswordProvider, SimpleDbAuthProvider, AuthProvider, User } from '../src/index.js';
+import { Configuration } from '@spinajs/configuration';
+import { SqliteOrmDriver } from '@spinajs/orm-sqlite';
+import { Orm } from '@spinajs/orm';
+import { join, normalize, resolve } from 'path';
+import { TestConfiguration } from './common.test.js';
+
+import './migration/rbac.migration.js';
+import { ResourceModel } from './models/ResourceModel.js';
+
+chai.use(chaiAsPromised);
+
+function dir(path: string) {
+  return resolve(normalize(join(process.cwd(), 'test', path)));
+}
+
+describe('Model ownership helpers', function () {
+  this.timeout(15000);
+
+  before(async () => {
+    DI.register(SimpleDbAuthProvider).as(AuthProvider);
+    DI.register(TestConfiguration).as(Configuration);
+    DI.register(SqliteOrmDriver).as('orm-driver-sqlite');
+    DI.register(BasicPasswordProvider).as(PasswordProvider);
+  });
+
+  beforeEach(async () => {
+    const bootstrappers = await DI.resolve(Array.ofType(Bootstrapper));
+    for (const b of bootstrappers) {
+      await b.bootstrap();
+    }
+
+    await DI.resolve(Configuration, [null, null, [dir('./config')]]);
+    await DI.resolve(Orm);
+  });
+
+  afterEach(() => {
+    DI.clearCache();
+  });
+
+  async function seed() {
+    const owner = await User.query().whereAnything('test@spinajs.pl').firstOrFail();
+
+    const owned = new ResourceModel({ UserId: owner.Id });
+    await owned.insert();
+
+    const foreign = new ResourceModel({ UserId: owner.Id + 999 });
+    await foreign.insert();
+
+    return { owner, owned, foreign };
+  }
+
+  it('checkOwnership(primaryKey) returns true for an owned resource', async () => {
+    const { owner, owned } = await seed();
+    expect(await (ResourceModel as any).checkOwnership(owned.Id, owner)).to.be.true;
+  });
+
+  it('checkOwnership(primaryKey) returns false for a resource owned by someone else', async () => {
+    const { owner, foreign } = await seed();
+    expect(await (ResourceModel as any).checkOwnership(foreign.Id, owner)).to.be.false;
+  });
+
+  it('checkOwnership(model) returns true when the model instance is owned', async () => {
+    const { owner, owned } = await seed();
+    expect(await (ResourceModel as any).checkOwnership(owned, owner)).to.be.true;
+  });
+
+  it('checkOwnership(model) returns false when the model instance is not owned', async () => {
+    const { owner, foreign } = await seed();
+    expect(await (ResourceModel as any).checkOwnership(foreign, owner)).to.be.false;
+  });
+
+  it('ensureOwnership restricts a query to rows owned by the user', async () => {
+    const { owner } = await seed();
+
+    const rows = await (ResourceModel as any).ensureOwnership(ResourceModel.select(), owner);
+
+    expect(rows).to.be.an('array').with.length(1);
+    expect(rows[0].UserId).to.eq(owner.Id);
+  });
+
+  it('throws when the model has no @ResourceOwner() field', async () => {
+    const owner = await User.query().whereAnything('test@spinajs.pl').firstOrFail();
+    expect(() => (User as any).ensureOwnership(User.select(), owner)).to.throw();
+  });
+});

--- a/packages/rbac/test/user.test.ts
+++ b/packages/rbac/test/user.test.ts
@@ -1,5 +1,6 @@
 import { BasicPasswordProvider } from '../src/password.js';
-import { DI } from '@spinajs/di';
+import { Bootstrapper, DI } from '@spinajs/di';
+import { AccessControl } from 'accesscontrol';
 import chaiAsPromised from 'chai-as-promised';
 import * as chai from 'chai';
 import { PasswordProvider, SimpleDbAuthProvider, AuthProvider, User, UserMetadata } from '../src/index.js';
@@ -31,6 +32,11 @@ describe('User model tests', function () {
   });
 
   beforeEach(async () => {
+    const bootstrappers = await DI.resolve(Array.ofType(Bootstrapper));
+    for (const b of bootstrappers) {
+      await b.bootstrap();
+    }
+
     await DI.resolve(Configuration, [null, null, [dir('./config')]]);
     await DI.resolve(Orm);
   });
@@ -106,23 +112,89 @@ describe('User model tests', function () {
       expect(user2.Role.length).to.be.eq(2);
     });
 
-    it('canReadAny should work', async () => {});
+    it('Should convert roles to and from string to array', async () => {
+      const user = new User({
+        Email: 'roles@test.pl',
+        Login: 'roles user',
+        IsActive: true,
+        Uuid: TEST_USER_UUID_2,
+        Password: 'test',
+        Role: ['admin', 'user', 'editor'],
+      });
 
-    it('canUpdateAny should work', async () => {});
+      await user.insert();
 
-    it('canDeleteAny should work', async () => {});
+      // Role is stored as a delimited string (@Set) and must hydrate back to an array
+      const reloaded = await User.get(user.Id);
+      expect(reloaded.Role).to.be.an('array');
+      expect(reloaded.Role).to.have.members(['admin', 'user', 'editor']);
+    });
+  });
 
-    it('canCreateAny should work', async () => {});
+  describe('Permission checks (can*)', () => {
+    beforeEach(() => {
+      // editor has full :any grants on Article; viewer only has read:own
+      const ac = DI.get<AccessControl>('AccessControl')!;
+      ac.setGrants({
+        editor: {
+          Article: {
+            'create:any': ['*'],
+            'read:any': ['*'],
+            'update:any': ['*'],
+            'delete:any': ['*'],
+          },
+        },
+        viewer: {
+          Article: {
+            'read:own': ['*'],
+          },
+        },
+      });
+    });
 
-    it('canReadOwn should work', async () => {});
+    const editor = () => new User({ Role: ['editor'] });
+    const viewer = () => new User({ Role: ['viewer'] });
 
-    it('canUpdateOwn should work', async () => {});
+    it('canReadAny should work', () => {
+      expect(editor().canReadAny('Article').granted).to.be.true;
+      expect(viewer().canReadAny('Article').granted).to.be.false;
+    });
 
-    it('canDeleteOwn should work', async () => {});
+    it('canUpdateAny should work', () => {
+      expect(editor().canUpdateAny('Article').granted).to.be.true;
+      expect(viewer().canUpdateAny('Article').granted).to.be.false;
+    });
 
-    it('canCreateOwn should work', async () => {});
+    it('canDeleteAny should work', () => {
+      expect(editor().canDeleteAny('Article').granted).to.be.true;
+      expect(viewer().canDeleteAny('Article').granted).to.be.false;
+    });
 
-    it('Should convert roles to and from string to array', async () => {});
+    it('canCreateAny should work', () => {
+      expect(editor().canCreateAny('Article').granted).to.be.true;
+      expect(viewer().canCreateAny('Article').granted).to.be.false;
+    });
+
+    it('canReadOwn should work', () => {
+      // an :any grant implies :own
+      expect(editor().canReadOwn('Article').granted).to.be.true;
+      expect(viewer().canReadOwn('Article').granted).to.be.true;
+    });
+
+    it('canUpdateOwn should work', () => {
+      expect(editor().canUpdateOwn('Article').granted).to.be.true;
+      expect(viewer().canUpdateOwn('Article').granted).to.be.false;
+    });
+
+    it('canDeleteOwn should work', () => {
+      expect(editor().canDeleteOwn('Article').granted).to.be.true;
+      expect(viewer().canDeleteOwn('Article').granted).to.be.false;
+    });
+
+    it('canCreateOwn should work', () => {
+      expect(editor().canCreateOwn('Article').granted).to.be.true;
+      expect(viewer().canCreateOwn('Article').granted).to.be.false;
+    });
   });
 
   describe('User metadata', () => {

--- a/packages/rbac/test/write-ownership-idor.test.ts
+++ b/packages/rbac/test/write-ownership-idor.test.ts
@@ -1,0 +1,116 @@
+import { BasicPasswordProvider } from '../src/password.js';
+import { Bootstrapper, DI } from '@spinajs/di';
+import chaiAsPromised from 'chai-as-promised';
+import * as chai from 'chai';
+import { expect } from 'chai';
+import { PasswordProvider, SimpleDbAuthProvider, AuthProvider, User } from '../src/index.js';
+import { Configuration } from '@spinajs/configuration';
+import { SqliteOrmDriver } from '@spinajs/orm-sqlite';
+import { Orm } from '@spinajs/orm';
+import { AccessControl } from 'accesscontrol';
+import { AsyncLocalStorage } from 'async_hooks';
+import { join, normalize, resolve } from 'path';
+import { TestConfiguration } from './common.test.js';
+
+import './migration/rbac.migration.js';
+import { ResourceModel } from './models/ResourceModel.js';
+
+chai.use(chaiAsPromised);
+
+function dir(path: string) {
+  return resolve(normalize(join(process.cwd(), 'test', path)));
+}
+
+/**
+ * Ownership enforcement on write queries.
+ *
+ * The rbac query middleware injects "owner_field = current user" for :own
+ * scopes. Historically it ran only for SELECT builders, so UPDATE and DELETE
+ * escaped ownership entirely — any authenticated user with a :own grant could
+ * modify or delete rows they did not own (an IDOR). These tests exercise a
+ * properly registered resource model (@Model + @OrmResource + @ResourceOwner)
+ * and prove the constraint is now applied to writes.
+ */
+describe('Ownership enforcement on write queries (IDOR regression)', function () {
+  this.timeout(15000);
+
+  before(async () => {
+    DI.register(SimpleDbAuthProvider).as(AuthProvider);
+    DI.register(TestConfiguration).as(Configuration);
+    DI.register(SqliteOrmDriver).as('orm-driver-sqlite');
+    DI.register(BasicPasswordProvider).as(PasswordProvider);
+  });
+
+  beforeEach(async () => {
+    const bootstrappers = await DI.resolve(Array.ofType(Bootstrapper));
+    for (const b of bootstrappers) {
+      await b.bootstrap();
+    }
+
+    await DI.resolve(Configuration, [null, null, [dir('./config')]]);
+    await DI.resolve(Orm);
+
+    const ac = DI.get<AccessControl>('AccessControl')!;
+    ac.setGrants({
+      owner: {
+        Test: {
+          'update:own': ['*'],
+          'delete:own': ['*'],
+          'read:own': ['*'],
+        },
+      },
+    });
+  });
+
+  afterEach(() => {
+    DI.clearCache();
+  });
+
+  async function seed() {
+    const attacker = await User.query().whereAnything('test@spinajs.pl').firstOrFail();
+    const victim = await User.query().whereAnything('test-notactive@spinajs.pl').firstOrFail();
+
+    const attackerRow = new ResourceModel({ UserId: attacker.Id, Value: 'attacker' } as any);
+    await attackerRow.insert();
+
+    const victimRow = new ResourceModel({ UserId: victim.Id, Value: 'victim' } as any);
+    await victimRow.insert();
+
+    return { attacker, victim, attackerRow, victimRow };
+  }
+
+  it('UPDATE with :own scope cannot touch another user\'s row via an OR lookup', async () => {
+    const { attacker, attackerRow, victimRow } = await seed();
+    const store = DI.resolve(AsyncLocalStorage);
+
+    await store.run({ User: new User({ Id: attacker.Id, Role: ['owner'] }) }, async () => {
+      await ResourceModel.update({ Value: 'hacked' }).where(function () {
+        this.where('Id', attackerRow.Id).orWhere('Id', victimRow.Id);
+      });
+    });
+
+    const attackerAfter = await ResourceModel.where({ Id: attackerRow.Id }).firstOrFail();
+    const victimAfter = await ResourceModel.where({ Id: victimRow.Id }).firstOrFail();
+
+    expect(attackerAfter.Value).to.eq('hacked');
+    expect(victimAfter.Value).to.eq('victim');
+  });
+
+  it('DELETE with :own scope cannot delete another user\'s row via an OR lookup', async () => {
+    const { attacker, attackerRow, victimRow } = await seed();
+    const store = DI.resolve(AsyncLocalStorage);
+
+    await store.run({ User: new User({ Id: attacker.Id, Role: ['owner'] }) }, async () => {
+      await ResourceModel.destroy().where(function () {
+        this.where('Id', attackerRow.Id).orWhere('Id', victimRow.Id);
+      });
+    });
+
+    const attackerAfter = await ResourceModel.where({ Id: attackerRow.Id }).first();
+    const victimAfter = await ResourceModel.where({ Id: victimRow.Id }).first();
+
+    expect(attackerAfter).to.be.undefined;   // attacker deleted their own row
+    expect(victimAfter).to.be.not.undefined; // victim's row survives
+    expect(victimAfter!.Value).to.eq('victim');
+  });
+});

--- a/packages/templates/src/interfaces.ts
+++ b/packages/templates/src/interfaces.ts
@@ -2,8 +2,10 @@ import { IMappableService } from '@spinajs/di';
 import { AsyncService } from '@spinajs/di';
 import { Logger, Log } from '@spinajs/log';
 import { fs, IStat, URI } from '@spinajs/fs';
+import { Config } from '@spinajs/configuration';
 import { readFile, stat as localStat } from 'fs/promises';
 import { normalize } from 'path';
+import { IRenderOptions } from './progress.js';
 
 /**
  * How aggressively compiled templates are reused.


### PR DESCRIPTION
Security:
- orm: run query middleware for UPDATE/DELETE builders so :own ownership constraints are enforced on writes (previously only SELECT was checked, allowing any user with an *Own grant to update/delete any row)
- rbac-http-user: scope all own metadata routes explicitly by user_id and force user_id on insert (close metadata IDOR)
- rbac-http-admin: stop returning the plaintext temporary password from admin create-user
- rbac-http-user: refresh() stores the user UUID (not a dehydrated object) so RbacUserFactory can resolve the user on later requests

Correctness (core rbac):
- unban(): return user through the chain and delete ban metadata properly
- IsBanned: honor ban start + duration expiry
- password reset: read rbac.password.passwordResetWaitTime and treat the wait time as seconds
- create(): tolerate empty create-middleware config (default config broke it)
- cli: await activate/deactivate/ban actions; de-duplicate command id
- implement ensureOwnership/checkOwnership (were declared but unimplemented)
- 2fa verifyToken: report ActiveRole and resolve grants for the active role

Build blockers (required to run the suites):
- queue: guard sqlite-incompatible Status enum migration (documented no-op)
- fs: remove unused import; templates: add missing Config/IRenderOptions imports

Tests:
- repair pre-existing compile/setup breakage in rbac test suite
- fill empty stubs (unban, changePassword, grant/revoke, password reset, can* checks) and add ownership + write-ownership IDOR + refresh regressions @