### PR TITLE
docs(orm): add exhaustive documentation for the ORM package family

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,7 +61,7 @@ jspm_packages/
 tsconfig.tsbuildinfo
 
 # doc ( generated typedoc output, per package )
-packages/*/docs/
+packages/*/api-docs/
 
 lib/
  
@@ -84,3 +84,6 @@ packages/orm-http/test/cache/
 
 # agent worktree pointers (local only)
 .claude/worktrees/
+
+# docs:check scratch (scripts/check-doc-samples.mjs)
+.tmp/

--- a/docs/superpowers/specs/2026-07-27-orm-documentation-design.md
+++ b/docs/superpowers/specs/2026-07-27-orm-documentation-design.md
@@ -1,0 +1,112 @@
+# ORM documentation — design
+
+Date: 2026-07-27
+
+## Goal
+
+Exhaustive, feature-grouped prose documentation for the ORM family of `@spinajs`
+packages. The packages currently ship `README.md` stubs containing only
+`> TODO: description`, and their `typedoc.json` files produce symbol dumps with no
+narrative. Nothing explains how to define a model, build a query, wire a relation, or
+expose a model over HTTP.
+
+## Scope
+
+In scope, each with its own `docs/` folder:
+
+| Package | Emphasis |
+| --- | --- |
+| `@spinajs/orm` | Core. Decorators, model API, query builders, relations, unit of work, schema/migrations, architecture. |
+| `@spinajs/orm-sql` | Shared SQL statement/compiler layer; how a dialect driver is built on it. |
+| `@spinajs/orm-http` | Integration with `@spinajs/http`: route args, filtering, DTO relations. |
+| `@spinajs/orm-api` | Generated JSON:API CRUD controller. |
+| `@spinajs/orm-sqlite` | Dialect driver notes. |
+| `@spinajs/orm-mysql` | Dialect driver notes. |
+| `@spinajs/orm-mssql` | Dialect driver notes. |
+
+Out of scope: `orm-threading`, `intl-orm`, `queue-orm-transport`, and downstream
+consumers (`rbac`, `session-provider-db`, `configuration-db-source`).
+
+## Audience and depth
+
+Two layers in every package:
+
+1. **User guide** — task-oriented, sample-first. How to do the thing.
+2. **Architecture** — how it works inside, for people extending or debugging it.
+
+The architecture material is not filler. The ORM source carries a number of
+non-obvious invariants documented only in code comments (composite-key join column
+defaults, inherited-descriptor detachment, positional key backfill after a multi-row
+insert on dialects without `RETURNING`). Those belong in prose.
+
+## Layout
+
+```
+packages/<pkg>/docs/README.md      index + reading order
+packages/<pkg>/docs/NN-topic.md    one feature group per file
+packages/<pkg>/README.md           short real overview, links into docs/
+```
+
+### Collision with typedoc
+
+`packages/*/docs/` was already the typedoc output directory: gitignored in both the root and
+each package's own `.gitignore`, and destroyed on every run by
+`"build-docs": "rimraf docs && typedoc ..."`. Prose placed there would never be committed and
+would be deleted by the next docs build.
+
+Resolved by treating prose as source and generated HTML as an artifact — the generated output
+moves, the prose stays where it was specified. In all seven packages:
+
+- `typedoc.json` — `"out": "docs"` → `"out": "api-docs"`
+- `package.json` — `rimraf docs` → `rimraf api-docs`
+- root `.gitignore` — `packages/*/docs/` → `packages/*/api-docs/`
+- each package `.gitignore` — `docs` → `api-docs`
+
+`packages/orm/docs/` holds 13 numbered files plus an index:
+
+1. `01-getting-started.md`
+2. `02-configuration.md`
+3. `03-models-and-decorators.md`
+4. `04-static-model-api.md`
+5. `05-instance-api.md`
+6. `06-query-builder.md`
+7. `07-relations.md`
+8. `08-unit-of-work.md`
+9. `09-transactions.md`
+10. `10-schema-and-migrations.md`
+11. `11-converters-and-hydration.md`
+12. `12-architecture.md`
+13. `13-observability.md`
+
+Satellite packages get 4–6 files each on the same pattern.
+
+## Code samples
+
+Samples are derived from the packages' own test suites and mock models, then reshaped
+into idiomatic application code rather than test code. Nothing is invented: every
+decorator, method, option name and behaviour claim traces to source.
+
+### Verification
+
+`scripts/check-doc-samples.mjs`:
+
+1. Walks `packages/*/docs/**/*.md`.
+2. Extracts fenced blocks whose info string is `ts sample`.
+3. Writes each to `.tmp/docs-samples/<pkg>/<file>-<n>.ts`.
+4. Emits a `tsconfig.json` beside them and runs `tsc --noEmit`.
+
+Each tagged block is self-contained and carries its own imports. Blocks that are
+deliberately partial use a plain ` ```ts ` fence and are skipped. Non-TypeScript
+fences (`sql`, `json`, `bash`) are ignored.
+
+Root `package.json` gains `"docs:check"`. Because npm workspaces resolve
+`@spinajs/*` to each package's built `lib/`, `npm run build` must precede
+`docs:check`. No CI wiring — the script is invoked manually.
+
+## Non-goals
+
+- Replacing typedoc. The prose links to it, it does not enumerate every symbol
+  signature.
+- Refactoring ORM source. Where the code has rough edges, the docs describe the
+  behaviour as it is and flag the sharp edge.
+- Documenting packages that merely consume the ORM.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "npm run clean && tsc -b tsconfig.build.json &&  tsc -b tsconfig.build.cjs.json && npm run copy-static && npm run prepare-module-support",
     "publish": "npm run build && npm publish --workspaces",
     "copy-static": "cpx packages/http/src/views/**/* packages/http/lib/views &&  cpx packages/http/src/static/**/* packages/http/lib/static && cpx \"packages/http-swagger/src/views/**/*.{pug,js}\" packages/http-swagger/lib/views",
-    "prepare-module-support": "node scripts/generate-packages-for-modules.mjs"
+    "prepare-module-support": "node scripts/generate-packages-for-modules.mjs",
+    "docs:check": "node scripts/check-doc-samples.mjs"
   },
   "workspaces": [
     "packages/*"

--- a/packages/orm-api/.gitignore
+++ b/packages/orm-api/.gitignore
@@ -61,6 +61,6 @@ jspm_packages/
 tsconfig.tsbuildinfo
 
 # doc
-docs
+api-docs
 
 lib

--- a/packages/orm-api/README.md
+++ b/packages/orm-api/README.md
@@ -1,11 +1,87 @@
-# `orm-http`
+# `@spinajs/orm-api`
 
-> TODO: description
+Building blocks for CRUD controllers over [`@spinajs/orm`](../orm) models: a route argument that
+resolves a model *type* from a URL segment, query-argument DTOs for filtering / including /
+paging, a pluggable collection transformer, and a policy that validates the requested model.
+
+## Read this first
+
+The name suggests a ready-made generic CRUD API. It is **not** that today.
+
+| Component | State |
+| --- | --- |
+| `JsonApi` controller (`src/controllers/JsonApi.ts`) | **Entirely commented out.** This package registers no routes. |
+| `Crud` base controller | Ships and works. |
+| `ModelType()` + `FindModelType` | Ship and work. |
+| `QueryArgs`, `QueryFilter`, `QueryIncludes` | Ship and work. |
+| `PlainJsonCollectionTransformer` | Ships; is the registered default. |
+| `FromModel` / `AsModel` | Ship, but are an older, less capable copy of [`@spinajs/orm-http`](../orm-http)'s. |
+| `RepositoryMiddleware` | Defined but not exported, and nothing invokes it. |
+| `src/index.ts` | Re-exports only the four route-argument symbols; everything else is unreachable by specifier. |
+| Bundled config `system.dirs.controllers` | Points at a directory in `@spinajs/orm-http` that does not exist. |
+| Bundled config transformer | Names `JsonApiCollectionTransformer`, which is registered nowhere. |
+| Test suite | Does not run — fails in `before all` with `No __file_provider_instance__ registered`, and asserts against `collection/*` routes no controller defines. |
+
+**Use this package for its pieces and write the controller yourself.** If you only need route
+arguments and filtering, prefer [`@spinajs/orm-http`](../orm-http) — it is the maintained one.
 
 ## Usage
 
-```
-const ormHttp = require('orm-http');
+```ts
+import { BaseController, BasePath, Get, Ok, Policy, Query } from '@spinajs/http';
+import { IModelStatic, ModelBase } from '@spinajs/orm';
+import { Autoinject } from '@spinajs/di';
+// Reachable only by relative path — see the docs.
+import { Crud, CollectionApiTransformer, _assertSingleColumnKey } from '../../src/interfaces.js';
+import { ModelType } from '../../src/route-args/ModelType.js';
+import { FindModelType } from '../../src/policies/FindModelType.js';
+import { QueryArgs } from '../../src/dto/QueryArgs.js';
 
-// TODO: DEMONSTRATE API
+@BasePath('collection')
+@Policy(FindModelType)
+export class Collection extends Crud {
+  @Autoinject(CollectionApiTransformer)
+  protected Transformer: CollectionApiTransformer;
+
+  /** GET /collection/:model */
+  @Get(':model')
+  public async list(@ModelType() model: IModelStatic, @Query() args: QueryArgs) {
+    const perPage = args?.perPage && args.perPage > 0 ? Math.min(args.perPage, 100) : 25;
+    const page = args?.page && args.page > 0 ? args.page : 0;
+
+    const query = model.query().select('*');
+    const totalCount = await (query.clone() as any).selectCount();
+    const data = await query.take(perPage).skip(page * perPage);
+
+    return new Ok(this.Transformer.transform(data as ModelBase[], { model: model as any, totalCount, currentPage: page, perPage }));
+  }
+}
+```
+
+`FindModelType` validates the `:model` segment; `ModelType()` resolves it to the model class,
+without a guard of its own — so always pair the two.
+
+## Documentation
+
+Full documentation lives in **[docs/](docs/)**.
+
+| | Page |
+| --- | --- |
+| 01 | [Overview](docs/01-overview.md) |
+| 02 | [Configuration](docs/02-configuration.md) |
+| 03 | [Building a CRUD controller](docs/03-building-a-crud-controller.md) |
+| 04 | [Query arguments](docs/04-query-args.md) |
+| 05 | [Transformers and policies](docs/05-transformers-and-policies.md) |
+
+## Security note
+
+A generic `/:model` controller exposes **every registered model**, including internal ones.
+`FindModelType` answers "is this a real model" and authorises nothing. Put an authorisation
+policy in front of it, or keep an allow-list of exposed model names.
+
+## Development
+
+```bash
+npm run build
+npm run docs:check   # from the repo root
 ```

--- a/packages/orm-api/docs/01-overview.md
+++ b/packages/orm-api/docs/01-overview.md
@@ -1,0 +1,140 @@
+# Overview
+
+## Exports
+
+Everything reachable from `@spinajs/orm-api`'s entry point:
+
+| Export | Kind | Purpose |
+| --- | --- | --- |
+| `AsDbModel`, `FromDbModel` | `RouteArgs` | Build / load a model from a request. |
+| `AsModel(field?)`, `FromModel(options?)` | decorators | Their decorator forms. |
+| `DbModelHydrator` | `ArgHydrator` | Hydrates a model from a request value. |
+| `OrmHttpBootstrapper` | `Bootstrapper` | Sets `DbModelHydrator` as every model's arg hydrator. |
+
+`src/index.ts` re-exports nothing else. The remaining pieces live in their own modules and are
+reachable only when your bundler or `ts-node` setup resolves package-internal paths — the
+`package.json` `exports` map exposes `"."` only.
+
+| Module | Contents |
+| --- | --- |
+| `interfaces.ts` | `Crud`, `CollectionApiTransformer`, `JsonApiIncomingObject`, `ITransformOptions`, `FromModelOptions`, `IQueryFilterEntry`, `_assertSingleColumnKey` |
+| `PlainJsonCollectionTransformer.ts` | The default transformer. |
+| `route-args/ModelType.ts` | `ModelType()` and `ModelTypeRouteArgs`. |
+| `policies/FindModelType.ts` | `FindModelType`. |
+| `dto/*.ts` | `QueryArgs`, `QueryFilter`, `QueryIncludes`. |
+| `hydrators/*.ts` | `GetFilterHydrator`, `QueryIncludesHydrator`. |
+| `schemas/*.ts` | The JSON schemas behind those DTOs. |
+| `middleware.ts` | `RepositoryMiddleware` — unexported, uninvoked. |
+| `config/orm-api.ts` | The bundled configuration. |
+
+In practice, applications in this repository import these by relative path from their own source
+tree, which is how the package's own tests do it.
+
+## Bootstrapping
+
+`OrmHttpBootstrapper` runs on `di.resolved.Orm` and sets `DbModelHydrator` as the
+`custom:arg_hydrator` for every discovered model, so a model used as a plain `@Body()` parameter
+arrives hydrated.
+
+Unlike `@spinajs/orm-http`'s bootstrapper, this one does **not** install any static mixins — no
+`filter()`, `filterColumns()` or `filterSchema()`. Filtering here goes through `QueryFilter`
+instead.
+
+```ts sample
+import { DI, Bootstrapper } from '@spinajs/di';
+import { Orm } from '@spinajs/orm';
+import '@spinajs/orm-api';
+
+export async function bootstrap() {
+  const bootstrappers = await DI.resolve(Array.ofType(Bootstrapper));
+  for (const b of bootstrappers) {
+    await b.bootstrap();
+  }
+
+  return await DI.resolve(Orm);
+}
+```
+
+Importing both this package and `@spinajs/orm-http` registers two bootstrappers that both set
+`custom:arg_hydrator` to their own `DbModelHydrator`. The implementations are equivalent, so the
+result is the same either way — but it is a reason to pick one package rather than both.
+
+## `orm-api` versus `orm-http`
+
+The two packages overlap substantially. `orm-http` is the newer and more capable of the pair.
+
+| Capability | `orm-api` | `orm-http` |
+| --- | --- | --- |
+| `@FromModel` | Yes | Yes, plus `queryField`, `paramField`, `include`, `OrmNotFoundException` |
+| Composite-key guard | `_assertSingleColumnKey` throws `BadRequest` | `queryField` escape hatch, and a clearer message |
+| Missing row | `firstOrFail()` | `firstOrThrow(new OrmNotFoundException(...))` → `404` via `OrmNotFound` |
+| `@AsModel` | Body only | Body / query / param / header, plus an empty-body guard |
+| Filtering | `QueryFilter` DTO, a flat `{ key: { val, op } }` map | `@Filterable` / `@Filter`, per-column operator whitelists, generated schema |
+| DTO relations | — | `@Relation` |
+| Model type from URL | `ModelType()` + `FindModelType` | — |
+| Collection transformer | `CollectionApiTransformer` | — |
+| Static mixins | — | `filter`, `filterColumns`, `filterSchema` |
+
+Use `orm-api` when you want the **generic** shape — one controller serving `/:model/:id` for
+every registered model. Use `orm-http` for hand-written, per-model controllers.
+
+## `FromModel` here
+
+The signature differs from `orm-http`'s in ways easy to trip over.
+
+`FromModelOptions` for this package:
+
+| Option | Meaning |
+| --- | --- |
+| `field` | The request field holding the key. Defaults to the parameter name. (`orm-http` calls this `paramField`.) |
+| `paramType` | `FromParams` (default), `FromQuery`, `FromBody`, `FromHeader`. |
+| `include` | Relations always populated. |
+| `noInclude` | Ignore the request's `include` / `_include`. |
+| `query` | Replace the whole query. Receives `callData.Payload` — not `(routeParams, value)` as in `orm-http`. |
+
+There is no `queryField`: the lookup column is always the primary key, and a composite key
+throws `BadRequest` from `_assertSingleColumnKey`.
+
+```ts sample
+import { BaseController, BasePath, Get, Ok } from '@spinajs/http';
+import { Connection, Model, ModelBase, Primary } from '@spinajs/orm';
+import { FromModel } from '@spinajs/orm-api';
+
+@Connection('default')
+@Model('articles')
+export class Article extends ModelBase<Article> {
+  @Primary()
+  public Id: number;
+
+  public Title: string;
+}
+
+@BasePath('articles')
+export class ArticleController extends BaseController {
+  /** GET /articles/:article */
+  @Get(':article')
+  public one(@FromModel() article: Article) {
+    return new Ok(article.dehydrate());
+  }
+}
+```
+
+The default query also applies the same **parent scoping** as `orm-http`: for each `belongsTo`
+relation, a route argument whose name matches the relation (case-insensitively, optionally
+`_`-prefixed) constrains the relation's foreign key.
+
+## `_assertSingleColumnKey`
+
+```ts
+export function _assertSingleColumnKey(descriptor: IModelDescriptor): string
+```
+
+Returns the single key column, or throws `BadRequest`:
+
+```
+model X has a composite primary key (A, B); the generic CRUD routes address rows by a single
+id and cannot serve it
+```
+
+Generic CRUD routes address a row by one `:id` segment, which cannot carry a composite key.
+Failing with a `400` beats a query that silently filters on half the key.

--- a/packages/orm-api/docs/02-configuration.md
+++ b/packages/orm-api/docs/02-configuration.md
@@ -1,0 +1,154 @@
+# Configuration
+
+## The bundled config
+
+`src/config/orm-api.ts` ships a configuration fragment that `@spinajs/configuration` merges in
+when the package is loaded:
+
+```ts
+const ormHttp = {
+  system: {
+    dirs: {
+      controllers: [dir(`node_modules/@spinajs/orm-http/lib/${isESMMode ? 'mjs/controllers' : 'cjs/controllers'}`)],
+      schemas: [dir(`node_modules/@spinajs/orm-http/lib/${isESMMode ? 'mjs/schemas' : 'cjs/schemas'}`)],
+    },
+  },
+  api: {
+    endpoint: {
+      transformer: {
+        service: 'JsonApiCollectionTransformer',
+      },
+    },
+  },
+};
+```
+
+Three things about it are worth knowing before you rely on it.
+
+**The controllers path does not exist.** It points into `@spinajs/orm-http`, which has no
+`controllers` directory — only `response-methods` and `schemas`. No controller is contributed by
+this configuration.
+
+**It points at the wrong package anyway.** This is `orm-api`'s config; the paths name
+`orm-http`. The commented-out `JsonApi` controller lives in *this* package's `src/controllers`.
+
+**The default transformer name does not resolve.** `JsonApiCollectionTransformer` is not
+registered anywhere in this repository. The transformer that *is* registered is
+`PlainJsonCollectionTransformer`.
+
+Set the transformer explicitly:
+
+```ts sample
+import { FrameworkConfiguration } from '@spinajs/configuration';
+import _ from 'lodash';
+
+export class AppConfiguration extends FrameworkConfiguration {
+  public async resolve(): Promise<void> {
+    await super.resolve();
+
+    this.Config = _.merge(this.Config, {
+      api: {
+        endpoint: {
+          transformer: {
+            // The implementation this repository actually registers.
+            service: 'PlainJsonCollectionTransformer',
+          },
+        },
+      },
+      system: {
+        dirs: {
+          // Point at YOUR controllers.
+          controllers: [`${process.cwd()}/lib/controllers`],
+        },
+      },
+    });
+  }
+}
+```
+
+## Configuration keys
+
+| Key | Meaning |
+| --- | --- |
+| `api.endpoint.transformer.service` | DI name of the `CollectionApiTransformer` implementation used to shape list and single-resource responses. |
+| `system.dirs.controllers` | Directories `@spinajs/http` scans for controllers. |
+| `system.dirs.schemas` | Directories `@spinajs/validation` scans for JSON schemas. |
+
+Everything else — connections, pools, migrations — is ORM configuration; see
+[the core's configuration page](../../orm/docs/02-configuration.md).
+
+## Resolving the configured transformer
+
+```ts
+import { DI } from '@spinajs/di';
+import { Configuration } from '@spinajs/configuration-common';
+import { CollectionApiTransformer } from '@spinajs/orm-api/lib/mjs/interfaces.js';
+
+export async function transformer(): Promise<CollectionApiTransformer> {
+  const cfg = await DI.resolve(Configuration);
+  const service = cfg.get<string>('api.endpoint.transformer.service', 'PlainJsonCollectionTransformer');
+
+  return await DI.resolve<CollectionApiTransformer>(service);
+}
+```
+
+Provide a default when reading the key, so a missing or stale value does not resolve `undefined`.
+
+## Registering your own transformer
+
+```ts
+import { Injectable } from '@spinajs/di';
+import { ModelBase } from '@spinajs/orm';
+import { CollectionApiTransformer, ITransformOptions } from '@spinajs/orm-api/lib/mjs/interfaces.js';
+
+@Injectable(CollectionApiTransformer)
+export class EnvelopeTransformer extends CollectionApiTransformer {
+  public transform(data: ModelBase<unknown> | ModelBase<unknown>[], options?: ITransformOptions): unknown {
+    if (Array.isArray(data)) {
+      return {
+        Data: data.map((x) => x.toJSON()),
+        Meta: {
+          Total: options?.totalCount ?? data.length,
+          Page: options?.currentPage ?? 0,
+          PerPage: options?.perPage ?? data.length,
+        },
+      };
+    }
+
+    return { Data: data.toJSON() };
+  }
+}
+```
+
+Register it under a name if you want to select it through configuration:
+
+```ts
+import { DI } from '@spinajs/di';
+import { PlainJsonCollectionTransformer } from '@spinajs/orm-api/lib/mjs/PlainJsonCollectionTransformer.js';
+
+export function register() {
+  DI.register(PlainJsonCollectionTransformer).as('PlainJsonCollectionTransformer');
+}
+```
+
+## Why the blocks above are not compile-verified
+
+Every other sample in these docs is extracted and type-checked by `npm run docs:check`. The
+three above are not, and cannot be: `@spinajs/orm-api`'s `package.json` declares
+`"exports": { "." : ... }`, and `src/index.ts` re-exports only the four route-argument symbols.
+`CollectionApiTransformer`, `PlainJsonCollectionTransformer`, `Crud`, `ModelType`,
+`FindModelType` and the DTOs are therefore **not importable from the package at all** — neither
+by the bare specifier nor by a deep path, which the `exports` map blocks.
+
+The `@spinajs/orm-api/lib/mjs/...` specifiers are written that way to name the module a symbol
+lives in, not because they resolve.
+
+Code inside this repository reaches them by **relative path** from its own source tree, which is
+what the package's own tests do:
+
+```ts
+import { CollectionApiTransformer } from '../../src/interfaces.js';
+```
+
+Adding the missing re-exports to `src/index.ts` would remove the need for either workaround, and
+would let these samples be verified like the rest.

--- a/packages/orm-api/docs/03-building-a-crud-controller.md
+++ b/packages/orm-api/docs/03-building-a-crud-controller.md
@@ -1,0 +1,224 @@
+# Building a CRUD controller
+
+Since this package ships no controller (see the [README](README.md)), here is how to assemble one
+from the parts it does provide.
+
+Everything below imports from `../../src/...`-style relative paths in the samples, because the
+package's `exports` map makes these symbols unreachable by specifier — see
+[02-configuration.md](02-configuration.md#why-the-blocks-above-are-not-compile-verified). The
+blocks on this page are therefore illustrative rather than compile-verified.
+
+## The generic shape
+
+A generic CRUD controller serves every registered model through one set of routes:
+
+```
+GET    /collection/:model                    list
+GET    /collection/:model/:id                one
+GET    /collection/:model/:id/:relation      a relation's members
+POST   /collection/:model                    create
+PATCH  /collection/:model/:id                update
+DELETE /collection/:model/:id                delete
+```
+
+Three pieces make `:model` work:
+
+- **`FindModelType`** — a policy that rejects an unknown model name before the route runs.
+- **`ModelType()`** — a route argument that resolves the URL segment to the model **class**.
+- **`Crud`** — a base controller with a helper for the relation routes.
+
+## `FindModelType`
+
+A `@Singleton` `BasePolicy`, always enabled, that validates `req.params.model`.
+
+```ts
+@Singleton()
+export class FindModelType extends BasePolicy {
+  isEnabled(): boolean { return true; }
+
+  execute(req: sRequest): Promise<void> {
+    if (!req.params) throw new InvalidOperation('Invalid query parameters');
+    if (!req.params.model) throw new InvalidOperation(`Invalid query parameters, 'model' is required`);
+
+    const model = Array.isArray(req.params.model) ? req.params.model[0] : req.params.model;
+    const mClass = this.Orm.Models.find((x) => x.name.toLowerCase() === model.trim().toLowerCase());
+    if (!mClass) throw new InvalidOperation(`Resource type ${req.params.model} was not found`);
+
+    return Promise.resolve();
+  }
+}
+```
+
+Matching is **case-insensitive and trimmed** against the model **class** name — not the table
+name. So `Article` is reachable as `/collection/article`.
+
+## `ModelType()`
+
+Resolves the segment to the model constructor and injects it.
+
+```ts
+export function ModelType() {
+  return Route(Parameter('ModelTypeRouteArgs'));
+}
+```
+
+It performs the same lookup as the policy, but **without** a guard: `.find(...)!.type` throws a
+`TypeError` on an unknown name. Always pair it with `@Policy(FindModelType)`, which turns that
+into a clean error first.
+
+## `Crud`
+
+An abstract `BaseController` with one helper:
+
+```ts
+protected prepareQuery(
+  model: IModelStatic,
+  relation: string,
+  id: any,
+  callback: (this: SelectQueryBuilder<...>, relation: IOrmRelation) => void,
+)
+```
+
+It builds `model.query().where(<single key column>, id).populate(relation, callback)` and returns
+`{ relation, relationModel, query }` — the relation descriptor, the target model's descriptor, and
+the builder.
+
+The key column comes from `_assertSingleColumnKey`, so a composite-key model produces a
+`BadRequest` rather than a half-filtered query.
+
+## A worked controller
+
+```ts
+import { Autoinject, DI } from '@spinajs/di';
+import { BaseController, BasePath, Get, Post, Patch, Del, Ok, Param, Body, Query, Policy } from '@spinajs/http';
+import { ModelBase, IModelStatic, SortOrder } from '@spinajs/orm';
+import { Crud, CollectionApiTransformer, _assertSingleColumnKey } from '../../src/interfaces.js';
+import { ModelType } from '../../src/route-args/ModelType.js';
+import { FindModelType } from '../../src/policies/FindModelType.js';
+import { QueryArgs } from '../../src/dto/QueryArgs.js';
+import { QueryIncludes } from '../../src/dto/QueryIncludes.js';
+
+@BasePath('collection')
+@Policy(FindModelType)
+export class Collection extends Crud {
+  @Autoinject(CollectionApiTransformer)
+  protected Transformer: CollectionApiTransformer;
+
+  /** GET /collection/:model */
+  @Get(':model')
+  public async list(@ModelType() model: IModelStatic, @Query() args: QueryArgs, @Query() includes: QueryIncludes) {
+    const perPage = args?.perPage && args.perPage > 0 ? args.perPage : 25;
+    const page = args?.page ?? 0;
+
+    const query = model.query().select('*');
+
+    if (includes) {
+      query.populate(includes as {});
+    }
+
+    // Clone BEFORE paging: a builder executes at most once, and count() clears columns.
+    const totalCount = await (query.clone() as any).selectCount();
+
+    query.take(perPage).skip(page * perPage);
+
+    if (args?.order) {
+      query.order(args.order, args.orderDirection ?? SortOrder.ASC);
+    }
+
+    const data = (await query) as ModelBase[];
+
+    return new Ok(this.Transformer.transform(data, { model: model as any, totalCount, currentPage: page, perPage }));
+  }
+
+  /** GET /collection/:model/:id */
+  @Get(':model/:id')
+  public async one(@ModelType() model: IModelStatic, @Param() id: string, @Query() includes: QueryIncludes) {
+    const descriptor = model.getModelDescriptor();
+    const query = model.query().select('*').where(_assertSingleColumnKey(descriptor), id);
+
+    if (includes) {
+      query.populate(includes as {});
+    }
+
+    const entity = await query.firstOrFail();
+
+    return new Ok(this.Transformer.transform(entity as ModelBase, { model: model as any }));
+  }
+
+  /** GET /collection/:model/:id/:relation */
+  @Get(':model/:id/:relation')
+  public async relation(@ModelType() model: IModelStatic, @Param() id: string, @Param() relation: string) {
+    const { query, relation: descriptor } = this.prepareQuery(model, relation, id, function () {});
+
+    const owner = (await query.firstOrFail()) as any;
+    const members = owner[descriptor.Name];
+
+    return new Ok(this.Transformer.transform([...members], { model: descriptor.TargetModel as any }));
+  }
+
+  /** POST /collection/:model */
+  @Post(':model')
+  public async create(@ModelType() model: IModelStatic, @Body() body: any) {
+    const entity = new (model as any)() as ModelBase;
+    entity.hydrate(body);
+    await entity.insert();
+
+    return new Ok(this.Transformer.transform(entity, { model: model as any }));
+  }
+
+  /** PATCH /collection/:model/:id */
+  @Patch(':model/:id')
+  public async update(@ModelType() model: IModelStatic, @Param() id: string, @Body() body: any) {
+    const descriptor = model.getModelDescriptor();
+    const entity = (await model.query().select('*').where(_assertSingleColumnKey(descriptor), id).firstOrFail()) as ModelBase;
+
+    entity.hydrate(body);
+    await entity.update();
+
+    return new Ok(this.Transformer.transform(entity, { model: model as any }));
+  }
+
+  /** DELETE /collection/:model/:id */
+  @Del(':model/:id')
+  public async remove(@ModelType() model: IModelStatic, @Param() id: string) {
+    const descriptor = model.getModelDescriptor();
+    const entity = (await model.query().select('*').where(_assertSingleColumnKey(descriptor), id).firstOrFail()) as ModelBase;
+
+    // Honours @SoftDelete automatically.
+    await entity.destroy();
+
+    return new Ok();
+  }
+}
+```
+
+## Things to get right
+
+**Authorisation.** A generic controller exposes every registered model, including internal ones.
+Put a policy in front of it, or maintain an allow-list of model names. `@spinajs/rbac-http`'s
+`RbacPolicy` is the intended companion — the package's own test fixtures stub it out.
+
+**Clone before counting.** A builder executes at most once, so awaiting it for the count and
+again for the page returns the memoized first result. `count()` also clears the column list.
+Clone first.
+
+**Mass assignment.** `entity.hydrate(body)` writes every matching column, including ones the
+caller should not control. Filter the body, or use `@Ignore()` and the model's `_hidden` list.
+
+**Composite keys.** Route them through `_assertSingleColumnKey` so they fail with a `400` rather
+than a wrong query.
+
+**Includes are attacker-controlled.** `QueryIncludes` turns `?includes=a.b.c` into a nested
+populate. A deep chain is a lot of queries; bound the depth if the endpoint is public.
+
+## Saving a graph instead
+
+For create and update, `save()` persists the whole reachable graph in one transaction, and its
+`Populated` rule means an unpopulated relation is left alone. See
+[the unit-of-work docs](../../orm/docs/08-unit-of-work.md).
+
+```ts
+const entity = new (model as any)() as ModelBase;
+entity.hydrate(body);
+const result = await entity.save();   // { Inserted, Updated, Deleted, ... }
+```

--- a/packages/orm-api/docs/04-query-args.md
+++ b/packages/orm-api/docs/04-query-args.md
@@ -1,0 +1,229 @@
+# Query arguments
+
+Three schema-validated DTOs for the query string. Each carries a `@Schema`; two also carry a
+`@Hydrator` that parses the raw string into a usable shape.
+
+As with the rest of this package, these live outside the entry point's `exports`, so the samples
+here import them by relative path and are not compile-verified — see
+[02-configuration.md](02-configuration.md#why-the-blocks-above-are-not-compile-verified).
+
+## `QueryArgs` — paging and sorting
+
+```ts
+@Schema(QueryArgsSchema)
+export class QueryArgs {
+  public page?: number;
+  public perPage?: number;
+  public orderDirection?: SortOrder;
+  public order?: string;
+}
+```
+
+Schema:
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "page": { "type": "number" },
+    "perPage": { "type": "number" },
+    "orderDirection": { "type": "string", "enum": ["ASC", "DESC", "asc", "desc"] },
+    "order": { "type": "string" }
+  }
+}
+```
+
+No hydrator — the values arrive as-is. Two things the schema does **not** do:
+
+- **No minimum on `page` or `perPage`.** A negative `perPage` reaches your code. `take()` rejects
+  a negative count, but bound it yourself rather than relying on an exception.
+- **No constraint on `order`.** It is a free-form string that you are about to pass to the query
+  builder as a column name. Whitelist it.
+
+```ts
+const SORTABLE = ['Id', 'Title', 'CreatedAt'];
+
+const perPage = args?.perPage && args.perPage > 0 ? Math.min(args.perPage, 100) : 25;
+const page = args?.page && args.page > 0 ? args.page : 0;
+
+const query = model.query().select('*').take(perPage).skip(page * perPage);
+
+if (args?.order && SORTABLE.includes(args.order)) {
+  query.order(args.order, args.orderDirection ?? SortOrder.ASC);
+}
+```
+
+Note that the ORM's builder does validate a column against the model descriptor when the builder
+has a model — `order` on an unknown column throws — so the whitelist is defence in depth rather
+than the only guard. It is still worth having: a valid-but-private column would otherwise be
+sortable.
+
+## `QueryIncludes` — relation population
+
+```ts
+@Hydrator(QueryIncludesHydrator)
+@Schema(QueryIncludesSchema)
+export class QueryIncludes {
+  [key: string]: string;
+}
+```
+
+The hydrator turns a comma-separated list of dotted paths into a nested object using lodash's
+`_.set`:
+
+```
+?includes=Author,Comments.Author
+```
+
+becomes
+
+```json
+{ "Author": {}, "Comments": { "Author": {} } }
+```
+
+which is exactly the object form `SelectQueryBuilder.populate()` accepts:
+
+```ts
+query.populate(includes as {});
+```
+
+An absent value hydrates to `{}`, so `populate({})` is a harmless no-op.
+
+Note the **mismatch** between the schema and the hydrator: `QueryIncludesSchema` declares
+
+```json
+{ "type": "array", "items": { "type": "string" } }
+```
+
+while the hydrator expects a **string** and calls `.split(',')` on it. Whether validation runs
+before or after hydration determines which shape has to satisfy the schema; the safest reading is
+that this schema does not describe what the hydrator consumes. Treat it as unvalidated input.
+
+An unknown relation name reaching `populate()` throws
+`Relation X not exists in model Y`, so a bad include is an error rather than a silent no-op.
+
+## `QueryFilter` — filtering
+
+```ts
+@Hydrator(GetFilterHydrator)
+@Schema(QueryFilterSchema)
+export class QueryFilter {
+  [key: string]: IQueryFilterEntry;
+}
+```
+
+The hydrator `JSON.parse`s the raw value, or yields an empty `QueryFilter` when absent:
+
+```ts
+export class GetFilterHydrator extends ArgHydrator {
+  public async hydrate(input: string): Promise<any> {
+    if (input) {
+      return new QueryFilter(JSON.parse(input));
+    }
+    return new QueryFilter({});
+  }
+}
+```
+
+The shape is a **map of column → `{ val, op }`**:
+
+```
+?filter={"Title":{"val":"typescript","op":"like"},"Views":{"val":100,"op":">"}}
+```
+
+`IQueryFilterEntry` is `{ val: string; op?: string }`.
+
+Schema:
+
+```json
+{
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "key": { "type": "string" },
+      "val": { "type": "number" },
+      "op": { "type": "string", "enum": ["=", "!=", "like", "<", ">", "<=", ">="] }
+    },
+    "required": ["key", "val"]
+  }
+}
+```
+
+Three mismatches to be aware of before relying on this schema:
+
+- It describes an **array** of `{ key, val, op }`; the class is a **map** of column →
+  `{ val, op }`. The hydrator produces the map.
+- It types `val` as a **number**, while `IQueryFilterEntry.val` is a **string**.
+- `JSON.parse` on malformed input throws a raw `SyntaxError`, which surfaces as a `500` rather
+  than a `400`.
+
+Unlike `@spinajs/orm-http`'s filtering, nothing here restricts **which columns** are filterable
+or **which operators** each column allows. Applying a `QueryFilter` straight to a query lets a
+client filter on any column of the table.
+
+```ts
+// Bound it yourself.
+const FILTERABLE: Record<string, string[]> = {
+  Title: ['=', 'like'],
+  Views: ['=', '>', '<'],
+};
+
+for (const [column, entry] of Object.entries(filter)) {
+  const allowed = FILTERABLE[column];
+  if (!allowed) continue;
+
+  const op = entry.op ?? '=';
+  if (!allowed.includes(op)) continue;
+
+  query.andWhere(column, op as any, entry.val);
+}
+```
+
+If you want operator whitelisting declared on the model itself, use `@spinajs/orm-http`'s
+`@Filterable` / `@Filter` instead — see
+[its filtering docs](../../orm-http/docs/03-filtering.md).
+
+## Using all three
+
+```ts
+@Get(':model')
+public async list(
+  @ModelType() model: IModelStatic,
+  @Query() args: QueryArgs,
+  @Query() includes: QueryIncludes,
+  @Query() filter: QueryFilter,
+) {
+  const perPage = args?.perPage && args.perPage > 0 ? Math.min(args.perPage, 100) : 25;
+  const page = args?.page && args.page > 0 ? args.page : 0;
+
+  const query = model.query().select('*');
+
+  if (includes) {
+    query.populate(includes as {});
+  }
+
+  applyFilter(query, filter);           // your whitelisting, as above
+
+  const totalCount = await (query.clone() as any).selectCount();
+
+  query.take(perPage).skip(page * perPage);
+
+  const data = await query;
+
+  return new Ok(this.Transformer.transform(data as ModelBase[], { model: model as any, totalCount, currentPage: page, perPage }));
+}
+```
+
+The parameter **name** is the query-string key `@Query()` reads, so these arrive as `?args=`,
+`?includes=` and `?filter=` respectively. Rename the parameters to change the keys.
+
+## Summary
+
+| DTO | Query key | Hydrated to | Validated |
+| --- | --- | --- | --- |
+| `QueryArgs` | the parameter name | Plain object | Types only — no bounds, no column whitelist |
+| `QueryIncludes` | the parameter name | Nested object for `populate()` | Schema does not match the hydrator's input |
+| `QueryFilter` | the parameter name | Map of column → `{ val, op }` | Schema does not match the hydrator's output |
+
+All three are usable; none of them is a security boundary on its own.

--- a/packages/orm-api/docs/05-transformers-and-policies.md
+++ b/packages/orm-api/docs/05-transformers-and-policies.md
@@ -1,0 +1,238 @@
+# Transformers and policies
+
+## `CollectionApiTransformer`
+
+The abstraction that shapes what a CRUD route returns, so the response format is a configuration
+choice rather than something baked into each controller.
+
+```ts
+export abstract class CollectionApiTransformer {
+  public abstract transform(data: ModelBase<unknown>[] | ModelBase<unknown>, options?: ITransformOptions): unknown;
+}
+```
+
+It handles both a collection and a single model, so one implementation covers every route.
+
+### `ITransformOptions`
+
+| Field | Meaning |
+| --- | --- |
+| `model` | The model class. **Required.** |
+| `totalCount` | Rows matching before paging. |
+| `currentPage` | Zero-based page index. |
+| `perPage` | Page size. |
+| `order` | `SortOrder`. |
+| `orderBy` | Column name. |
+
+`model` is declared non-optional, but `PlainJsonCollectionTransformer` never reads it. A custom
+transformer that needs the model descriptor — to emit a JSON:API `type`, say — does.
+
+### `PlainJsonCollectionTransformer`
+
+The default, registered as `@Injectable(CollectionApiTransformer)`.
+
+```ts
+@Injectable(CollectionApiTransformer)
+export class PlainJsonCollectionTransformer extends CollectionApiTransformer {
+  public transform(data: ModelBase<unknown> | ModelBase<unknown>[], options?: ITransformOptions): unknown {
+    if (Array.isArray(data)) {
+      return {
+        Collection: data.map((x) => x.toJSON()),
+        Count: options!.totalCount,
+      };
+    }
+
+    return data.toJSON();
+  }
+}
+```
+
+A collection becomes `{ Collection, Count }`; a single model becomes its `toJSON()` — the
+`dehydrate()` output, so `@Ignore()` columns and the model's `_hidden` list are already excluded.
+
+Two things to note. `options!.totalCount` is dereferenced without a guard, so calling it for a
+collection **without** options throws — always pass at least `{ model, totalCount }`. And
+because it uses `toJSON()` rather than `dehydrateWithRelations()`, **populated relations do not
+appear in the output**. A transformer that should include them needs to say so:
+
+```ts
+@Injectable(CollectionApiTransformer)
+export class RelationAwareTransformer extends CollectionApiTransformer {
+  public transform(data: ModelBase<unknown> | ModelBase<unknown>[], options?: ITransformOptions): unknown {
+    if (Array.isArray(data)) {
+      return {
+        Data: data.map((x) => x.dehydrateWithRelations()),
+        Meta: {
+          Total: options?.totalCount ?? data.length,
+          Page: options?.currentPage ?? 0,
+          PerPage: options?.perPage ?? data.length,
+        },
+      };
+    }
+
+    return { Data: data.dehydrateWithRelations() };
+  }
+}
+```
+
+Remember that `dehydrateWithRelations` does **not** propagate `omit` into nested relations — the
+recursive calls pass `omit: []`. Hidden fields on a related model must be declared on that
+model's own `_hidden` list or with `@Ignore()`.
+
+### A JSON:API transformer
+
+The `JsonApiCollectionTransformer` named in the bundled configuration does not exist in this
+repository. The shape it would produce, from the commented-out controller:
+
+```ts
+@Injectable(CollectionApiTransformer)
+export class JsonApiCollectionTransformer extends CollectionApiTransformer {
+  public transform(data: ModelBase<unknown> | ModelBase<unknown>[], _options?: ITransformOptions): unknown {
+    const one = (model: ModelBase) => ({
+      type: model.constructor.name,
+      id: model.PrimaryKeyValue,
+      attributes: model.dehydrate(),
+      relationships: _.mapValues(_.groupBy(model.getFlattenRelationModels(false), '__relationKey__'), (group) =>
+        group.map((related) => ({ type: related.constructor.name, id: related.PrimaryKeyValue })),
+      ),
+    });
+
+    return {
+      data: Array.isArray(data) ? data.map(one) : one(data),
+      included: Array.isArray(data) ? _.flatMap(data, (m) => m.getFlattenRelationModels(true).map(one)) : data.getFlattenRelationModels(true).map(one),
+    };
+  }
+}
+```
+
+`__relationKey__` is set on related models by the ORM's `OneToManyRelationHydrator` and
+`OneToOneRelationHydrator` — it names the relation a model arrived through, which is what makes
+the `relationships` grouping possible.
+
+### Selecting one
+
+```ts
+const service = configuration.get<string>('api.endpoint.transformer.service', 'PlainJsonCollectionTransformer');
+const transformer = await DI.resolve<CollectionApiTransformer>(service);
+```
+
+Always pass a default — the bundled config's value (`JsonApiCollectionTransformer`) does not
+resolve.
+
+## `FindModelType`
+
+A `@Singleton` `BasePolicy` that validates the `:model` segment before the route body runs.
+
+```ts
+@Singleton()
+export class FindModelType extends BasePolicy {
+  @Autoinject()
+  protected Orm: Orm;
+
+  isEnabled(): boolean { return true; }
+
+  execute(req: sRequest): Promise<void> {
+    if (!req.params) throw new InvalidOperation('Invalid query parameters');
+    if (!req.params.model) throw new InvalidOperation(`Invalid query parameters, 'model' is required`);
+
+    const model = Array.isArray(req.params.model) ? req.params.model[0] : req.params.model;
+    const mClass = this.Orm.Models.find((x) => x.name.toLowerCase() === model.trim().toLowerCase());
+    if (!mClass) throw new InvalidOperation(`Resource type ${req.params.model} was not found`);
+
+    return Promise.resolve();
+  }
+}
+```
+
+- `isEnabled()` is unconditionally `true` — it runs wherever it is attached.
+- Matching is case-insensitive, trimmed, and against the **class** name, not the table name.
+- An array-valued parameter takes its first element.
+- Failures are `InvalidOperation`, whose status depends on your exception mapping — it is not a
+  `404` by default.
+
+**It authorises nothing.** It only answers "is this a real model". Every registered model,
+including internal ones, passes. Pair it with an authorisation policy:
+
+```ts
+@BasePath('collection')
+@Policy(RbacPolicy)
+@Policy(FindModelType)
+export class Collection extends Crud { /* ... */ }
+```
+
+Or keep an allow-list:
+
+```ts
+const PUBLIC_MODELS = new Set(['article', 'author', 'tag']);
+
+@Singleton()
+export class PublicModelsOnly extends BasePolicy {
+  isEnabled(): boolean { return true; }
+
+  execute(req: sRequest): Promise<void> {
+    const name = String(req.params?.model ?? '').trim().toLowerCase();
+    if (!PUBLIC_MODELS.has(name)) {
+      throw new InvalidOperation(`Resource type ${req.params?.model} was not found`);
+    }
+    return Promise.resolve();
+  }
+}
+```
+
+Reusing the same "not found" message for a private model is deliberate: it avoids telling a
+caller which internal models exist.
+
+## `ModelTypeRouteArgs`
+
+```ts
+@Injectable()
+export class ModelTypeRouteArgs extends RouteArgs {
+  public get SupportedType(): string { return 'ModelTypeRouteArgs'; }
+
+  public async extract(callData: IRouteCall, _args: unknown[], param: IRouteParameter, req: express.Request) {
+    const rawParam = req.params[param.Name];
+    const modelParam = Array.isArray(rawParam) ? rawParam[0] : rawParam;
+    return Promise.resolve({
+      CallData: callData,
+      Args: this.Orm.Models.find((x) => x.name.toLowerCase() === modelParam.trim().toLowerCase())!.type,
+    });
+  }
+}
+```
+
+Injected via the `ModelType()` decorator. It resolves the segment to the model **class**, so the
+route receives something it can call statics on.
+
+The `!` is load-bearing and unguarded: an unknown model name throws
+`Cannot read properties of undefined (reading 'type')`, and `modelParam.trim()` throws on a
+missing parameter. **`FindModelType` is what makes this safe** — attach it, always.
+
+`param.Name` is the route parameter read, so `@ModelType() model: IModelStatic` on a
+`':model'` route reads `:model`.
+
+## Putting them together
+
+```ts
+@BasePath('collection')
+@Policy(FindModelType)
+export class Collection extends Crud {
+  @Autoinject(CollectionApiTransformer)
+  protected Transformer: CollectionApiTransformer;
+
+  @Get(':model')
+  public async list(@ModelType() model: IModelStatic, @Query() args: QueryArgs) {
+    const perPage = args?.perPage && args.perPage > 0 ? Math.min(args.perPage, 100) : 25;
+    const page = args?.page && args.page > 0 ? args.page : 0;
+
+    const query = model.query().select('*');
+    const totalCount = await (query.clone() as any).selectCount();
+
+    const data = await query.take(perPage).skip(page * perPage);
+
+    return new Ok(this.Transformer.transform(data as ModelBase[], { model: model as any, totalCount, currentPage: page, perPage }));
+  }
+}
+```
+
+See [03-building-a-crud-controller.md](03-building-a-crud-controller.md) for the full set of
+routes.

--- a/packages/orm-api/docs/README.md
+++ b/packages/orm-api/docs/README.md
@@ -1,0 +1,39 @@
+# `@spinajs/orm-api` documentation
+
+Building blocks for CRUD controllers over ORM models: route arguments that resolve a model
+*type* from a URL segment, query-argument DTOs for filtering / including / paging, a pluggable
+collection transformer, and a policy that validates the requested model.
+
+## Read this first — what the package actually ships
+
+The name suggests a generic, ready-made CRUD API. It is **not** that today.
+
+| Component | State |
+| --- | --- |
+| `JsonApi` controller (`src/controllers/JsonApi.ts`) | **Entirely commented out.** No routes are registered by this package. |
+| `Crud` base controller | Ships, exported, usable. |
+| `ModelType()` route argument + `FindModelType` policy | Ship and work. |
+| `QueryArgs`, `QueryFilter`, `QueryIncludes` DTOs + schemas | Ship and work. |
+| `PlainJsonCollectionTransformer` | Ships and is the default. |
+| `FromModel` / `AsModel` route args | Ship, but are an older, less capable copy of the ones in [`@spinajs/orm-http`](../../orm-http/docs/). |
+| `RepositoryMiddleware` | Defined but **not exported**, and nothing invokes it. |
+| Bundled config `system.dirs.controllers` | Points at `node_modules/@spinajs/orm-http/lib/*/controllers`, a directory that does not exist. |
+| Test suite | Does not run — it fails in `before all` with `No __file_provider_instance__ registered`, and its assertions target `collection/*` routes that no controller in this repository defines. |
+
+So: use this package for its **pieces**, and write the controller yourself. If you only need
+route arguments and filtering, prefer `@spinajs/orm-http` — it is the maintained one.
+
+## Pages
+
+| | Page | Covers |
+| --- | --- | --- |
+| 01 | [Overview](01-overview.md) | Exports, bootstrapping, the relationship to orm-http |
+| 02 | [Configuration](02-configuration.md) | The bundled config and what to override |
+| 03 | [Building a CRUD controller](03-building-a-crud-controller.md) | Using `Crud`, `ModelType()` and `FindModelType` to build the routes yourself |
+| 04 | [Query arguments](04-query-args.md) | `QueryArgs`, `QueryFilter`, `QueryIncludes` and their hydrators |
+| 05 | [Transformers and policies](05-transformers-and-policies.md) | `CollectionApiTransformer`, `PlainJsonCollectionTransformer`, `FindModelType` |
+
+## Related
+
+- [`@spinajs/orm-http`](../../orm-http/docs/) — the maintained HTTP integration
+- [`@spinajs/orm`](../../orm/docs/) — the core

--- a/packages/orm-api/package.json
+++ b/packages/orm-api/package.json
@@ -24,7 +24,7 @@
     "clean": "rimraf lib/ && rimraf tsconfig.tsbuildinfo",
     "test": "ts-mocha -p tsconfig.json test/**/*.test.ts",
     "coverage": "nyc npm run test",
-    "build-docs": "rimraf docs && typedoc --options typedoc.json src/",
+    "build-docs": "rimraf api-docs && typedoc --options typedoc.json src/",
     "format": "prettier --write \"src/**/*.ts\"",
     "lint": "eslint -c .eslintrc.cjs --ext .ts src --fix",
     "preversion": "npm run lint",

--- a/packages/orm-api/typedoc.json
+++ b/packages/orm-api/typedoc.json
@@ -1,6 +1,6 @@
 {
     "mode": "modules",
-    "out": "docs",
+    "out": "api-docs",
     "name": "spine",
     "theme": "default",
     "ignoreCompilerErrors": "true",

--- a/packages/orm-http/.gitignore
+++ b/packages/orm-http/.gitignore
@@ -61,6 +61,6 @@ jspm_packages/
 tsconfig.tsbuildinfo
 
 # doc
-docs
+api-docs
 
 lib

--- a/packages/orm-http/README.md
+++ b/packages/orm-http/README.md
@@ -1,11 +1,100 @@
-# `orm-http`
+# `@spinajs/orm-http`
 
-> TODO: description
+Glue between [`@spinajs/orm`](../orm) and `@spinajs/http`: route arguments that load or build
+models straight from a request, a declarative filtering layer, and DTO fields that resolve to
+database entities.
+
+It does **not** generate controllers or routes. You write ordinary `@spinajs/http` controllers;
+this package removes the boilerplate inside them.
+
+## Install
+
+```bash
+npm install @spinajs/orm-http
+```
+
+Importing it is enough — its bootstrapper registers itself with DI and runs when the ORM
+resolves.
 
 ## Usage
 
-```
-const ormHttp = require('orm-http');
+```ts
+import { BaseController, BasePath, Get, Post, Ok } from '@spinajs/http';
+import { Connection, Model, ModelBase, Primary } from '@spinajs/orm';
+import { FromModel, AsModel, Filter, Filterable, IFilterRequest } from '@spinajs/orm-http';
 
-// TODO: DEMONSTRATE API
+@Connection('default')
+@Model('articles')
+export class Article extends ModelBase<Article> {
+  @Primary()
+  public Id: number;
+
+  @Filterable(['eq', 'like'])
+  public Title: string;
+}
+
+@BasePath('articles')
+export class ArticleController extends BaseController {
+  /** GET /articles/:article — loaded by primary key, 404 when missing. */
+  @Get(':article')
+  public one(@FromModel() article: Article) {
+    return new Ok(article.dehydrate());
+  }
+
+  /** GET /articles?filter={"op":"and","filters":[{"Column":"Title","Operator":"like","Value":"x"}]} */
+  @Get()
+  public async list(@Filter(Article) filter: IFilterRequest) {
+    const rows = await Article.select().filter(filter.filters, filter.op);
+    return new Ok(rows.map((r) => r.dehydrate()));
+  }
+
+  /** POST /articles — hydrated from the body, not fetched or saved. */
+  @Post()
+  public async create(@AsModel() article: Article) {
+    await article.insert();
+    return new Ok(article.dehydrate());
+  }
+}
+```
+
+## What it adds
+
+| Feature | Entry point |
+| --- | --- |
+| Load a model from a route / query / body / header parameter | `@FromModel()` |
+| Build an unsaved model from the request body | `@AsModel()` |
+| Declarative, schema-validated filtering | `@Filterable()` + `@Filter()` |
+| DTO fields that resolve to entities | `@Relation()` |
+| Pagination and ordering DTOs | `PaginationDTO`, `OrderDTO` |
+| `404` for `OrmNotFoundException` | `OrmNotFound` |
+
+It also installs `filter()`, `filterColumns()` and `filterSchema()` onto every model class.
+
+## Documentation
+
+Full documentation lives in **[docs/](docs/)**.
+
+| | Page |
+| --- | --- |
+| 01 | [Overview](docs/01-overview.md) |
+| 02 | [Route arguments](docs/02-route-args.md) |
+| 03 | [Filtering](docs/03-filtering.md) |
+| 04 | [DTO relations](docs/04-dto-relations.md) |
+| 05 | [Pagination and ordering](docs/05-pagination-and-order.md) |
+| 06 | [Repository middleware](docs/06-repository-middleware.md) |
+
+## Known issues
+
+- `RepositoryMiddleware` is defined in `src/middleware.ts` but re-exported from neither
+  `src/index.ts` nor the `exports` map, so it is currently unreachable. Use `QueryMiddleware`
+  from the core instead — see [docs/06](docs/06-repository-middleware.md).
+- `npm test` fails during bootstrap with `No __file_provider_instance__ registered`: the test
+  harness does not register `@spinajs/fs`. That is a test-configuration gap, not a defect in the
+  package.
+
+## Development
+
+```bash
+npm run build
+npm run docs:check   # from the repo root
 ```

--- a/packages/orm-http/docs/01-overview.md
+++ b/packages/orm-http/docs/01-overview.md
@@ -1,0 +1,112 @@
+# Overview
+
+## What it adds
+
+| Feature | Entry point |
+| --- | --- |
+| Load a model from a route / query / body / header parameter | `@FromModel()` |
+| Build an unsaved model from the request body | `@AsModel()` |
+| Declarative, schema-validated filtering | `@Filterable()` + `@Filter()` |
+| DTO fields that resolve to database entities | `@Relation()` |
+| Pagination and ordering DTOs | `PaginationDTO`, `OrderDTO` |
+| A `404` response for `OrmNotFoundException` | `OrmNotFound` |
+| CRUD lifecycle hooks | `RepositoryMiddleware` |
+
+## Bootstrapping
+
+`OrmHttpBootstrapper` is registered as a `Bootstrapper` and runs on `di.resolved.Orm`, so it
+fires the first time the ORM resolves. It does two things to **every** discovered model:
+
+1. Sets `DbModelHydrator` as the model's `custom:arg_hydrator`, so a model used as a plain
+   `@Body()` parameter is hydrated rather than left as a raw object.
+2. Binds this package's `MODEL_STATIC_MIXINS` — `filter()`, `filterColumns()` and
+   `filterSchema()` — onto the model class.
+
+Importing the package is enough; DI finds the bootstrapper.
+
+```ts sample
+import { DI, Bootstrapper } from '@spinajs/di';
+import { Orm } from '@spinajs/orm';
+import '@spinajs/orm-http';
+
+export async function bootstrap() {
+  const bootstrappers = await DI.resolve(Array.ofType(Bootstrapper));
+  for (const b of bootstrappers) {
+    await b.bootstrap();
+  }
+
+  // OrmHttpBootstrapper's `di.resolved.Orm` hook fires here.
+  return await DI.resolve(Orm);
+}
+```
+
+Because the mixins are attached at ORM-resolve time, they are **not** available while a
+controller class is being constructed. `FilterModelRouteArg` works around this by building the
+filter schema at request time rather than at decoration time.
+
+## Module augmentation
+
+`extension.ts` augments `@spinajs/orm`'s own types, so the additions are visible wherever the
+core types are:
+
+```ts
+declare module '@spinajs/orm' {
+  export interface IModelDescriptor {
+    FilterableColumns?: Map<string, IColumnFilter<unknown>>;
+  }
+
+  export interface ISelectQueryBuilder {
+    filter(filter: IFilter[], logicalOperator?: FilterableLogicalOperators, filters?: IColumnFilter<unknown>[]): this;
+  }
+
+  namespace ModelBase {
+    export function filterSchema(): any;
+    export function filterColumns(): IColumnFilter<unknown>[];
+    export function filter<T extends ModelBase<unknown>>(filterRequest: IFilterRequest): Promise<Array<T>>;
+  }
+}
+```
+
+`SelectQueryBuilder.prototype.filter` is installed by direct prototype assignment in
+`builders.ts`, at module load — not through DI.
+
+## Statics added to every model
+
+| Static | Returns |
+| --- | --- |
+| `filterColumns()` | `[{ column, operators, query }]` for every `@Filterable` column. `[]` when the model has none. |
+| `filterSchema()` | A JSON schema validating an `IFilterRequest` against those columns. `{}` when the model has none. |
+| `filter(request)` | A `SelectQueryBuilder` with the filter applied. |
+
+## Package exports
+
+| Export | Kind | Purpose |
+| --- | --- | --- |
+| `FromModel`, `AsModel` | decorators | Route arguments. |
+| `FromDbModel`, `AsDbModel` | `RouteArgs` | Their implementations. |
+| `DbModelHydrator` | `ArgHydrator` | Hydrates a model from a request value. |
+| `Filterable`, `Filter` | decorators | Filtering. |
+| `FilterModelRouteArg` | `RouteArgs` | Extracts and validates a filter. |
+| `Relation`, `RelationResolverHydrator` | decorator + hydrator | DTO relations. |
+| `PaginationDTO`, `OrderDTO` | DTOs | Paging and sorting. |
+| `RepositoryMiddleware` | abstract | CRUD lifecycle hooks. |
+| `OrmNotFound` | `Response` | `404` for `OrmNotFoundException`. |
+| `JsonApiIncomingObject` | DTO | JSON:API request body shape. |
+| `FromModelOptions`, `IColumnFilter`, `IFilter`, `IFilterRequest`, `ITransformOptions` | types | |
+| `FilterableOperators`, `FilterableLogicalOperators` | types / enum | |
+| `MODEL_STATIC_MIXINS` | object | The statics listed above. |
+
+## Composite primary keys
+
+Two places refuse to guess, and both say so with a `400`-shaped error rather than silently
+filtering on half a key:
+
+- `@FromModel()` — a route parameter carries one value, so pass `queryField` to name a single
+  lookup column.
+- `@Relation()` — a DTO relation field carries one value, so set `by`.
+
+## Error responses
+
+`OrmNotFound` is registered as a `Response` handling `OrmNotFoundException`, mapping it to
+`404 NOT FOUND` and the `notFound.pug` template. Since `@FromModel()` uses `firstOrThrow(new
+OrmNotFoundException(...))`, a missing row becomes a `404` with no work on your part.

--- a/packages/orm-http/docs/02-route-args.md
+++ b/packages/orm-http/docs/02-route-args.md
@@ -1,0 +1,286 @@
+# Route arguments
+
+## `@FromModel(options?)` — load from the database
+
+Reads a value from the request, queries the model, and injects the row. A miss throws
+`OrmNotFoundException`, which `OrmNotFound` renders as `404`.
+
+```ts sample
+import { BaseController, BasePath, Get, Ok } from '@spinajs/http';
+import { Connection, Model, ModelBase, Primary } from '@spinajs/orm';
+import { FromModel } from '@spinajs/orm-http';
+
+@Connection('default')
+@Model('articles')
+export class Article extends ModelBase<Article> {
+  @Primary()
+  public Id: number;
+
+  public Title: string;
+
+  public Slug: string;
+}
+
+@BasePath('articles')
+export class ArticleController extends BaseController {
+  /**
+   * GET /articles/:article
+   *
+   * The parameter NAME is the route parameter read by default — `:article` here.
+   */
+  @Get(':article')
+  public byId(@FromModel() article: Article) {
+    return new Ok(article.dehydrate());
+  }
+}
+```
+
+### `FromModelOptions`
+
+| Option | Default | Meaning |
+| --- | --- | --- |
+| `paramField` | the parameter's name | Which request field holds the value. |
+| `paramType` | `FromParams` | Where to read it: `FromParams`, `FromQuery`, `FromBody`, `FromHeader`. |
+| `queryField` | the model's primary key | Which **column** to filter on. |
+| `include` | — | Relations always populated, regardless of the request. |
+| `noInclude` | `false` | Ignore `include` / `_include` from the request. |
+| `query` | — | Replace the whole default query. |
+
+Header names are lowercased before lookup.
+
+```ts sample
+import { BaseController, BasePath, Get, Ok, ParameterType } from '@spinajs/http';
+import { Connection, Model, ModelBase, Primary } from '@spinajs/orm';
+import { FromModel } from '@spinajs/orm-http';
+
+@Connection('default')
+@Model('articles')
+export class Article extends ModelBase<Article> {
+  @Primary()
+  public Id: number;
+
+  public Slug: string;
+
+  public Title: string;
+}
+
+@BasePath('articles')
+export class ArticleController extends BaseController {
+  /** GET /articles/by-slug/:slug — look the row up by a natural key. */
+  @Get('by-slug/:slug')
+  public bySlug(@FromModel<typeof Article>({ paramField: 'slug', queryField: 'Slug' }) article: Article) {
+    return new Ok(article.dehydrate());
+  }
+
+  /** GET /articles/current?id=123 */
+  @Get('current')
+  public fromQuery(@FromModel<typeof Article>({ paramField: 'id', paramType: ParameterType.FromQuery }) article: Article) {
+    return new Ok(article.dehydrate());
+  }
+
+  /** Always populate a relation, and ignore whatever `include` the caller asked for. */
+  @Get('fixed/:article')
+  public fixedIncludes(@FromModel<typeof Article>({ include: ['Author'], noInclude: true }) article: Article) {
+    return new Ok(article.dehydrateWithRelations());
+  }
+}
+```
+
+### The default query
+
+With no `query` callback, `fromDbModelDefaultQueryFunction` builds:
+
+1. `SELECT *` from the model's table, aliased `$<table>$`.
+2. `WHERE <queryField> = <value>`.
+3. **Parent scoping.** For every `belongsTo` relation, if a route parameter shares its name
+   (case-insensitively, optionally `_`-prefixed), the relation's foreign key is constrained to
+   that parameter. A matching parameter with no value throws
+   `no key for relation X was provided`.
+4. `populate(options.include)` when given.
+5. Unless `noInclude`, `populate(...)` of the request's `include` or `_include` query argument.
+6. `firstOrThrow(new OrmNotFoundException('Resource not found'))`.
+
+Step 3 is what makes nested resources work without writing the join:
+
+```ts sample
+import { BaseController, BasePath, Get, Ok, Param } from '@spinajs/http';
+import { Connection, Model, ModelBase, Primary, BelongsTo, SingleRelation } from '@spinajs/orm';
+import { FromModel } from '@spinajs/orm-http';
+
+@Connection('default')
+@Model('authors')
+export class Author extends ModelBase<Author> {
+  @Primary()
+  public Id: number;
+
+  public Name: string;
+}
+
+@Connection('default')
+@Model('articles')
+export class Article extends ModelBase<Article> {
+  @Primary()
+  public Id: number;
+
+  public author_id: number;
+
+  public Title: string;
+
+  @BelongsTo(Author, 'author_id', 'Id')
+  public Author: SingleRelation<Author>;
+}
+
+@BasePath('authors')
+export class NestedController extends BaseController {
+  /**
+   * GET /authors/:author/articles/:article
+   *
+   * `:author` matches the `Author` relation by name, so the query is automatically
+   * constrained to `author_id = :author` — an article belonging to a different
+   * author 404s instead of leaking.
+   */
+  @Get(':author/articles/:article')
+  public one(@Param() _author: number, @FromModel() article: Article) {
+    return new Ok(article.dehydrate());
+  }
+}
+```
+
+### Composite primary keys
+
+A route parameter carries one value. Without `queryField`, a model whose key has more than one
+column throws a `BadRequest`:
+
+```
+model X has a composite primary key (A, B); pass queryField to select a single lookup column
+```
+
+### A custom query
+
+`query` replaces the default entirely. `this` is the model's select builder; the arguments are
+the route's arguments and the extracted value.
+
+```ts sample
+import { BaseController, BasePath, Get, Ok } from '@spinajs/http';
+import { Connection, Model, ModelBase, Primary, SelectQueryBuilder } from '@spinajs/orm';
+import { FromModel } from '@spinajs/orm-http';
+
+@Connection('default')
+@Model('articles')
+export class Article extends ModelBase<Article> {
+  @Primary()
+  public Id: number;
+
+  public Slug: string;
+
+  public Published: boolean;
+}
+
+@BasePath('articles')
+export class CustomQueryController extends BaseController {
+  @Get('published/:slug')
+  public published(
+    @FromModel<typeof Article>({
+      paramField: 'slug',
+      query: function (this: SelectQueryBuilder<typeof Article>, _routeParams: any, value: any) {
+        return (this as unknown as SelectQueryBuilder<Article>).select('*').where('Slug', value).andWhere('Published', true) as SelectQueryBuilder;
+      },
+    })
+    article: Article,
+  ) {
+    return new Ok(article.dehydrate());
+  }
+}
+```
+
+The callback's result is awaited through `firstOrThrow(new OrmNotFoundException('Resource not
+found'))`, so it should return a builder, not a promise.
+
+## `@AsModel(field?, type?)` — build without loading
+
+Constructs a model from the request body and hydrates it. It **does not** query the database and
+**does not** save. Effectively a typed `@Body()` that produces a model instance.
+
+```ts sample
+import { BaseController, BasePath, Post, Ok, Patch } from '@spinajs/http';
+import { Connection, Model, ModelBase, Primary } from '@spinajs/orm';
+import { AsModel, FromModel } from '@spinajs/orm-http';
+
+@Connection('default')
+@Model('articles')
+export class Article extends ModelBase<Article> {
+  @Primary()
+  public Id: number;
+
+  public Title: string;
+
+  public Body: string;
+}
+
+@BasePath('articles')
+export class WriteController extends BaseController {
+  @Post()
+  public async create(@AsModel() article: Article) {
+    await article.insert();
+    return new Ok(article.dehydrate());
+  }
+
+  /** Load the existing row, then patch it from the body. */
+  @Patch(':article')
+  public async update(@FromModel() article: Article, @AsModel('patch') patch: Article) {
+    article.hydrate(patch.dehydrate({ ignoreNullable: true }) as Partial<Article>);
+    await article.update();
+    return new Ok(article.dehydrate());
+  }
+}
+```
+
+Which part of the body is used:
+
+- `req.body[param.Name]` when that key exists;
+- otherwise the **whole body**, but only when the route has exactly one `AsDbModel` parameter;
+- otherwise `null`.
+
+An empty body throws `BadRequest('Request body empty, cannot hydrate model for parameter ...')`.
+
+## `DbModelHydrator`
+
+Registered as the `custom:arg_hydrator` for every model by `OrmHttpBootstrapper`. It constructs
+the model and hydrates it from the incoming value, which is what makes a plain `@Body()` typed as
+a model work:
+
+```ts sample
+import { BaseController, BasePath, Post, Ok, Body } from '@spinajs/http';
+import { Connection, Model, ModelBase, Primary } from '@spinajs/orm';
+
+@Connection('default')
+@Model('articles')
+export class Article extends ModelBase<Article> {
+  @Primary()
+  public Id: number;
+
+  public Title: string;
+}
+
+@BasePath('articles')
+export class BodyController extends BaseController {
+  /** `article` arrives as a hydrated Article, not a plain object. */
+  @Post()
+  public async create(@Body() article: Article) {
+    await article.insert();
+    return new Ok({ Id: article.Id });
+  }
+}
+```
+
+A `null` input throws `OrmException('primary key cannot be null')`.
+
+## Choosing between them
+
+| Need | Use |
+| --- | --- |
+| An existing row, 404 when absent | `@FromModel()` |
+| A new unsaved instance from the body | `@AsModel()` or `@Body()` |
+| A row plus a patch | Both — `@FromModel()` for the row, `@AsModel('patch')` for the changes |
+| A row by natural key | `@FromModel({ queryField: 'Slug' })` |
+| A row scoped to its parent | `@FromModel()` with the parent's relation name as a route parameter |

--- a/packages/orm-http/docs/03-filtering.md
+++ b/packages/orm-http/docs/03-filtering.md
@@ -1,0 +1,336 @@
+# Filtering
+
+A declarative filtering layer: the model declares which columns are filterable and with which
+operators, and the route argument validates an incoming filter against a JSON schema generated
+from those declarations. A client cannot filter on a column you did not open up, nor with an
+operator you did not allow.
+
+## Declaring filterable columns
+
+```ts sample
+import { Connection, Model, ModelBase, Primary, BelongsTo, SingleRelation } from '@spinajs/orm';
+import { Filterable } from '@spinajs/orm-http';
+
+@Connection('default')
+@Model('authors')
+export class Author extends ModelBase<Author> {
+  @Primary()
+  public Id: number;
+
+  @Filterable(['eq', 'like'])
+  public Name: string;
+}
+
+@Connection('default')
+@Model('articles')
+export class Article extends ModelBase<Article> {
+  @Primary()
+  public Id: number;
+
+  public author_id: number;
+
+  @Filterable(['eq', 'like', 'b-like', 'e-like'])
+  public Title: string;
+
+  @Filterable(['eq', 'gt', 'gte', 'lt', 'lte', 'between'])
+  public Views: number;
+
+  @Filterable(['isnull', 'notnull'])
+  public PublishedAt: string;
+
+  /**
+   * Passing a MODEL instead of an operator list imports that model's filterable
+   * columns under this property's name — `Author.Name` becomes filterable here.
+   */
+  @Filterable(Author)
+  @BelongsTo(Author, 'author_id', 'Id')
+  public Author: SingleRelation<Author>;
+}
+```
+
+`@Filterable` also touches the column descriptor: it creates a `Virtual` column entry when the
+property has none, and sets `Aggregate` from the third argument.
+
+```ts
+Filterable(
+  operatorsOrClass: FilterableOperators[] | Constructor<ModelBase>,
+  queryFunc?: (operator: FilterableOperators, value: any) => WhereFunction<unknown>,
+  isAggregate?: boolean,
+)
+```
+
+Passing a model whose own filterable columns are empty contributes nothing — declare
+`@Filterable` on the related model's columns first.
+
+## Operators
+
+| Operator | SQL |
+| --- | --- |
+| `eq` | `= ?` |
+| `neq` | `!= ?` |
+| `gt` / `gte` / `lt` / `lte` | `> ?` / `>= ?` / `< ?` / `<= ?` |
+| `like` | `LIKE '%value%'` |
+| `b-like` | `LIKE '%value'` — *begins* the wildcard, i.e. matches at the end |
+| `e-like` | `LIKE 'value%'` — matches at the start |
+| `regexp` | `REGEXP ?` |
+| `between` / `notbetween` | `BETWEEN` / `NOT BETWEEN` |
+| `isnull` / `notnull` | `IS NULL` / `IS NOT NULL` |
+| `in` / `nin` | `IN (...)` / `NOT IN (...)` |
+| `in-set` / `nin-set` | `FIND_IN_SET` membership |
+| `exists` / `n-exists` | `EXISTS` / `NOT EXISTS` on a relation |
+
+Value validation per operator:
+
+| Operators | Requirement |
+| --- | --- |
+| `in`, `nin`, `in-set`, `nin-set` | An array with at least one value. |
+| `between`, `notbetween` | An array with at least two values. |
+| `like`, `b-like`, `e-like`, `regexp` | A non-empty string (`null`/`undefined` skip the check). |
+| `eq`, `neq`, `gt`, `gte`, `lt`, `lte` | A defined value. |
+| `isnull`, `notnull`, `exists`, `n-exists` | No value needed. |
+
+## The `@Filter()` route argument
+
+```ts sample
+import { BaseController, BasePath, Get, Ok } from '@spinajs/http';
+import { Connection, Model, ModelBase, Primary } from '@spinajs/orm';
+import { Filter, Filterable, IFilterRequest } from '@spinajs/orm-http';
+
+@Connection('default')
+@Model('articles')
+export class Article extends ModelBase<Article> {
+  @Primary()
+  public Id: number;
+
+  @Filterable(['eq', 'like'])
+  public Title: string;
+
+  @Filterable(['eq', 'gt', 'lt'])
+  public Views: number;
+}
+
+@BasePath('articles')
+export class ArticleController extends BaseController {
+  /** Derive the allowed filters from the model. */
+  @Get()
+  public async list(@Filter(Article) filter: IFilterRequest) {
+    const rows = await Article.select().filter(filter.filters, filter.op);
+    return new Ok(rows.map((r) => r.dehydrate()));
+  }
+
+  /** Or spell the allowed columns out inline. */
+  @Get('custom')
+  public async custom(
+    @Filter([
+      { column: 'Title', operators: ['eq', 'like'] },
+      { column: 'Views', operators: ['gt'] },
+    ])
+    filter: IFilterRequest,
+  ) {
+    const rows = await Article.select().filter(filter.filters, filter.op);
+    return new Ok(rows.map((r) => r.dehydrate()));
+  }
+}
+```
+
+The value is read from `req.query[paramName]` first, then `req.body[paramName]`. A string is
+`JSON.parse`d; malformed JSON becomes an `InvalidArgument` (a client error), not an unhandled
+500.
+
+The schema is built at **request** time, not decoration time — the `filterSchema()` static is
+installed by `OrmHttpBootstrapper` when the ORM resolves, which is after controllers are
+constructed.
+
+## Request shape
+
+```json
+{
+  "op": "and",
+  "filters": [
+    { "Column": "Title", "Operator": "like", "Value": "typescript" },
+    { "Column": "Views", "Operator": "gt", "Value": 100 }
+  ]
+}
+```
+
+As a query string:
+
+```
+GET /articles?filter=%7B%22op%22%3A%22and%22%2C%22filters%22%3A%5B%7B%22Column%22%3A%22Title%22%2C%22Operator%22%3A%22like%22%2C%22Value%22%3A%22ts%22%7D%5D%7D
+```
+
+`op` is `and` or `or` (`FilterableLogicalOperators`); anything other than `or` is treated as
+`and`. Note the field names are **capitalised** — `Column`, `Operator`, `Value`.
+
+## The generated schema
+
+`Model.filterSchema()` produces:
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "op": { "type": "string", "enum": ["and", "or"] },
+    "filters": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "anyOf": [
+          {
+            "type": "object",
+            "required": ["Column", "Operator"],
+            "properties": {
+              "Column": { "const": "Title" },
+              "Value": { "type": ["string", "integer", "array", "boolean"] },
+              "Operator": { "type": "string", "enum": ["eq", "like"] }
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+`Value` is deliberately **not** required — the valueless operators (`isnull`, `notnull`,
+`exists`, `n-exists`) carry none. A model with no `@Filterable` columns returns `{}`.
+
+## Applying a filter
+
+`SelectQueryBuilder.filter(filters, logicalOperator?, filterColumns?)` is installed on the
+prototype at module load.
+
+Every filter is wrapped in a single `andWhere(function () { ... })` group, so it composes with
+conditions you added yourself rather than fighting them.
+
+Before applying anything it checks: at most **100** filters; each entry is an object with a
+`Column` and an `Operator`; the operator is known; the column is in the filterable list; and the
+operator is allowed for that column. Any failure throws.
+
+```ts sample
+import { Connection, Model, ModelBase, Primary } from '@spinajs/orm';
+import { Filterable, IFilterRequest } from '@spinajs/orm-http';
+
+@Connection('default')
+@Model('articles')
+export class Article extends ModelBase<Article> {
+  @Primary()
+  public Id: number;
+
+  public Published: boolean;
+
+  @Filterable(['eq', 'like'])
+  public Title: string;
+}
+
+export async function combined(filter: IFilterRequest) {
+  // The client's filter is one AND-group; our own condition sits alongside it.
+  return await Article.select().where('Published', true).filter(filter.filters, filter.op).orderByDescending('Id').take(50);
+}
+```
+
+## Filtering a relation
+
+`filter()` is available on any select builder, including the one a `populate` callback receives.
+
+```ts sample
+import { BaseController, BasePath, Get, Ok } from '@spinajs/http';
+import { Connection, Model, ModelBase, Primary, HasMany, Relation } from '@spinajs/orm';
+import { Filter, Filterable, IFilterRequest } from '@spinajs/orm-http';
+
+@Connection('default')
+@Model('comments')
+export class Comment extends ModelBase<Comment> {
+  @Primary()
+  public Id: number;
+
+  public article_id: number;
+
+  @Filterable(['eq', 'like'])
+  public Body: string;
+}
+
+@Connection('default')
+@Model('articles')
+export class Article extends ModelBase<Article> {
+  @Primary()
+  public Id: number;
+
+  @HasMany(Comment, { foreignKey: 'article_id', primaryKey: 'Id' })
+  public Comments: Relation<Comment, Article>;
+}
+
+@BasePath('articles')
+export class RelationFilterController extends BaseController {
+  @Get('with-comments')
+  public async list(@Filter(Comment) filter: IFilterRequest) {
+    const rows = await Article.select().populate('Comments', function () {
+      this.filter(filter.filters, filter.op);
+    });
+
+    return new Ok(rows.map((r) => r.dehydrateWithRelations()));
+  }
+}
+```
+
+## A custom query per column
+
+`@Filterable`'s second argument replaces the generated predicate entirely — for computed
+columns, or a column whose filter should span several database columns.
+
+```ts sample
+import { Connection, Model, ModelBase, Primary, WhereFunction } from '@spinajs/orm';
+import { Filterable, FilterableOperators } from '@spinajs/orm-http';
+
+@Connection('default')
+@Model('people')
+export class Person extends ModelBase<Person> {
+  @Primary()
+  public Id: number;
+
+  public FirstName: string;
+
+  public LastName: string;
+
+  /**
+   * A virtual column: filtering `FullName` searches both real name columns.
+   * The callback receives the operator and the value, and returns a where function.
+   */
+  @Filterable(['like'], (_operator: FilterableOperators, value: any): WhereFunction<unknown> => {
+    return function () {
+      this.where('FirstName', 'like', `%${value}%`).orWhere('LastName', 'like', `%${value}%`);
+    };
+  })
+  public FullName: string;
+}
+```
+
+When a column declares a custom query, validation of the value is skipped — the callback owns it.
+
+## Inspecting what is filterable
+
+```ts sample
+import { Connection, Model, ModelBase, Primary } from '@spinajs/orm';
+import { Filterable } from '@spinajs/orm-http';
+
+@Connection('default')
+@Model('articles')
+export class Article extends ModelBase<Article> {
+  @Primary()
+  public Id: number;
+
+  @Filterable(['eq', 'like'])
+  public Title: string;
+}
+
+export function describe() {
+  return {
+    // [{ column: 'Title', operators: ['eq', 'like'], query: undefined }]
+    columns: (Article as any).filterColumns(),
+    schema: (Article as any).filterSchema(),
+  };
+}
+```
+
+Both are useful for generating client-side filter UIs, and `filterSchema()` is what
+`http-swagger` documents the endpoint with.

--- a/packages/orm-http/docs/04-dto-relations.md
+++ b/packages/orm-http/docs/04-dto-relations.md
@@ -1,0 +1,261 @@
+# DTO relations
+
+`@Relation` marks a DTO field as a **reference to a database entity**. On an incoming request the
+field's value is looked up, and the field is replaced with the resolved model instance — so the
+route body arrives with real entities rather than bare ids you then have to fetch.
+
+## Declaring one
+
+```ts sample
+import { Schema } from '@spinajs/validation';
+import { Connection, Model, ModelBase, Primary } from '@spinajs/orm';
+import { Relation } from '@spinajs/orm-http';
+
+@Connection('default')
+@Model('users')
+export class User extends ModelBase<User> {
+  @Primary()
+  public Id: number;
+
+  public Uuid: string;
+
+  public Email: string;
+}
+
+@Schema({
+  type: 'object',
+  $id: 'app.CampaignDTO',
+  properties: {
+    Name: { type: 'string' },
+    author: { type: 'string' },
+  },
+})
+export class CampaignDTO {
+  public Name?: string;
+
+  /** Incoming: a Uuid string. Delivered to the route: a User instance. */
+  @Relation(() => User, { by: 'Uuid' })
+  public author?: string | User;
+
+  constructor(data: Partial<CampaignDTO>) {
+    Object.assign(this, data);
+  }
+}
+```
+
+The target is a **thunk** — `() => User`, not `User` — so the DTO can reference a model without
+an import cycle and without needing the class to exist at decoration time.
+
+`IRelationOptions.by` names the column to look up on. It defaults to the target's primary key.
+
+## Using it
+
+```ts sample
+import { BaseController, BasePath, Post, Ok, Body } from '@spinajs/http';
+import { Schema } from '@spinajs/validation';
+import { Connection, Model, ModelBase, Primary } from '@spinajs/orm';
+import { Relation } from '@spinajs/orm-http';
+
+@Connection('default')
+@Model('users')
+export class User extends ModelBase<User> {
+  @Primary()
+  public Id: number;
+
+  public Uuid: string;
+}
+
+@Schema({
+  type: 'object',
+  $id: 'app.CreateCampaign',
+  properties: {
+    Name: { type: 'string' },
+    author: { type: 'string' },
+  },
+  required: ['Name', 'author'],
+})
+export class CreateCampaign {
+  public Name: string;
+
+  @Relation(() => User, { by: 'Uuid' })
+  public author: User;
+
+  constructor(data: Partial<CreateCampaign>) {
+    Object.assign(this, data);
+  }
+}
+
+@BasePath('campaigns')
+export class CampaignController extends BaseController {
+  /**
+   * POST /campaigns  { "Name": "Spring", "author": "3f2a..." }
+   *
+   * `dto.author` is already a User row — no lookup here, and a bad Uuid
+   * became a 404 before this method ran.
+   */
+  @Post()
+  public create(@Body() dto: CreateCampaign) {
+    return new Ok({ Name: dto.Name, AuthorId: dto.author.Id });
+  }
+}
+```
+
+## How resolution works
+
+`RelationResolverHydrator` is registered as the DTO's `custom:arg_hydrator` by the decorator
+itself — **unless one is already set**, so an explicit `@Hydrator(...)` on the class wins.
+
+For each declared relation field, in parallel:
+
+1. `undefined` or `null` → skipped. An optional field is simply absent; a *required* one was
+   already rejected upstream by `@Schema` validation.
+2. Otherwise `target.where({ [by]: value }).firstOrThrow(new OrmNotFoundException(...))`.
+3. The field is overwritten with the resolved model.
+
+A miss produces `OrmNotFoundException` with the message
+`<Model> referenced by '<field>' not found`, which `OrmNotFound` renders as `404`.
+
+## `@Schema` is mandatory
+
+A DTO using `@Relation` **must** declare a `@Schema`, enforced once per class at first hydration:
+
+```
+DTO X uses @Relation but has no @Schema. All DTOs with @Relation must declare a @Schema.
+```
+
+The reason is the null-skipping rule above: resolution treats an absent field as optional, so
+required-ness has to be expressed — and enforced — by the schema. Without one, a missing required
+reference would slip through as `undefined`.
+
+The check result is memoised in a `WeakSet`, so it costs nothing after the first request.
+
+## Composite keys
+
+A DTO relation field carries one value, so a target with a composite primary key must name a
+single lookup column via `by`:
+
+```
+model X has a composite primary key (A, B); set `by` on the relation to select a single lookup column
+```
+
+## Inheritance
+
+Relation descriptors are stored through `getInheritedDescriptor`, so a subclass inherits its
+parent's `@Relation` fields. The documented pattern is to inherit the relations and ship a
+stricter schema:
+
+```ts sample
+import { Schema } from '@spinajs/validation';
+import { Connection, Model, ModelBase, Primary } from '@spinajs/orm';
+import { Relation } from '@spinajs/orm-http';
+
+@Connection('default')
+@Model('users')
+export class User extends ModelBase<User> {
+  @Primary()
+  public Id: number;
+
+  public Uuid: string;
+}
+
+@Schema({
+  type: 'object',
+  $id: 'app.CampaignBase',
+  properties: {
+    Name: { type: 'string' },
+    author: { type: 'string' },
+  },
+})
+export class CampaignDTO {
+  public Name?: string;
+
+  @Relation(() => User, { by: 'Uuid' })
+  public author?: User;
+
+  constructor(data: Partial<CampaignDTO>) {
+    Object.assign(this, data);
+  }
+}
+
+/** Same relation, inherited; only the schema changes. */
+@Schema({
+  type: 'object',
+  $id: 'app.CampaignStrict',
+  properties: {
+    Name: { type: 'string' },
+    author: { type: 'string' },
+  },
+  required: ['author'],
+})
+export class StrictCampaignDTO extends CampaignDTO {}
+```
+
+## Storing a resolved relation on a model
+
+The ORM's `DbPropertyHydrator` translates a `ModelBase` arriving on a foreign-key column into its
+primary key, and `OneToOneRelationHydrator` accepts a model instance under a relation name. So a
+resolved DTO relation can be handed straight to `hydrate`:
+
+```ts sample
+import { Connection, Model, ModelBase, Primary, BelongsTo, SingleRelation } from '@spinajs/orm';
+
+@Connection('default')
+@Model('users')
+export class User extends ModelBase<User> {
+  @Primary()
+  public Id: number;
+
+  public Uuid: string;
+}
+
+@Connection('default')
+@Model('campaigns')
+export class Campaign extends ModelBase<Campaign> {
+  @Primary()
+  public Id: number;
+
+  public author_id: number;
+
+  public Name: string;
+
+  @BelongsTo(User, 'author_id', 'Id')
+  public Author: SingleRelation<User>;
+}
+
+export async function persist(name: string, author: User) {
+  const campaign = new Campaign({ Name: name });
+
+  // Either works: the FK column receives the model's key,
+  campaign.hydrate({ author_id: author } as unknown as Partial<Campaign>);
+  // or the relation receives the model itself.
+  campaign.Author.attach(author);
+
+  await campaign.insert();
+  return campaign;
+}
+```
+
+## The metadata key
+
+Descriptors live on the DTO prototype under `Symbol.for('orm-http:relations')`, exported as
+`RELATION_SYMBOL`. It is a **global** symbol deliberately, so `@spinajs/http-swagger` can read it
+to document the endpoint without importing this package.
+
+```ts sample
+import { RELATION_SYMBOL, IDtoRelations } from '@spinajs/orm-http';
+import 'reflect-metadata';
+
+export function relationsOf(ctor: any): IDtoRelations | undefined {
+  return Reflect.getMetadata(RELATION_SYMBOL, ctor.prototype) as IDtoRelations | undefined;
+}
+```
+
+Each entry is an `IDtoRelationDescriptor`: `{ field, target, by? }`.
+
+## When to use which
+
+| Situation | Approach |
+| --- | --- |
+| A route parameter identifying the resource | `@FromModel()` |
+| A body field referencing another entity | `@Relation()` on the DTO |
+| A body that *is* the entity | `@AsModel()` or `@Body()` typed as the model |

--- a/packages/orm-http/docs/05-pagination-and-order.md
+++ b/packages/orm-http/docs/05-pagination-and-order.md
@@ -1,0 +1,205 @@
+# Pagination and ordering
+
+Two small schema-validated DTOs. They carry and validate the values; applying them to a query is
+left to you, because how a listing should page and sort is an application decision.
+
+## `PaginationDTO`
+
+```ts
+@Schema({
+  type: 'object',
+  $id: 'arrow.common.PaginationDTO',
+  properties: {
+    limit: { type: 'number', minimum: 0 },
+    page: { type: 'number', minimum: 0 },
+  },
+})
+export class PaginationDTO {
+  public limit: number;
+  public page: number;
+}
+```
+
+Both are non-negative numbers. Note the fields are `limit` and `page` — not `perPage` or
+`offset`.
+
+## `OrderDTO`
+
+```ts
+@Schema({
+  type: 'object',
+  $id: 'arrow.common.OrderDTO',
+  properties: {
+    order: { type: 'string', enum: ['ASC', 'DESC', 'asc', 'desc'] },
+    column: { type: 'string' },
+  },
+})
+export class OrderDTO {
+  public order: SortOrder;
+  public column: string;
+}
+```
+
+Both cases are accepted for `order`. `column` is **not** constrained by the schema — validate it
+against a whitelist yourself before passing it to the query builder, or a client can sort by any
+column in the table.
+
+## Using them
+
+```ts sample
+import { BaseController, BasePath, Get, Ok, Query } from '@spinajs/http';
+import { Connection, Model, ModelBase, Primary, SortOrder } from '@spinajs/orm';
+import { PaginationDTO, OrderDTO } from '@spinajs/orm-http';
+
+@Connection('default')
+@Model('articles')
+export class Article extends ModelBase<Article> {
+  @Primary()
+  public Id: number;
+
+  public Title: string;
+
+  public Views: number;
+}
+
+const SORTABLE = ['Id', 'Title', 'Views'];
+
+@BasePath('articles')
+export class ArticleController extends BaseController {
+  /** GET /articles?page=0&limit=25&column=Title&order=ASC */
+  @Get()
+  public async list(@Query() pagination: PaginationDTO, @Query() sort: OrderDTO) {
+    const limit = pagination?.limit && pagination.limit > 0 ? pagination.limit : 25;
+    const page = pagination?.page ?? 0;
+
+    const query = Article.select().take(limit).skip(page * limit);
+
+    // `column` is unconstrained by the schema — whitelist it.
+    if (sort?.column && SORTABLE.includes(sort.column)) {
+      query.order(sort.column, sort.order ?? SortOrder.ASC);
+    }
+
+    const rows = await query;
+    return new Ok(rows.map((r) => r.dehydrate()));
+  }
+}
+```
+
+## Counting for a paged response
+
+A builder executes at most once, so `clone()` before turning it into a count — otherwise the
+memoized result of the first execution comes back.
+
+`count()` also **clears the column list**, which is another reason to work on a clone.
+
+```ts sample
+import { BaseController, BasePath, Get, Ok, Query } from '@spinajs/http';
+import { Connection, Model, ModelBase, Primary } from '@spinajs/orm';
+import { PaginationDTO } from '@spinajs/orm-http';
+
+@Connection('default')
+@Model('articles')
+export class Article extends ModelBase<Article> {
+  @Primary()
+  public Id: number;
+
+  public Published: boolean;
+
+  public Title: string;
+}
+
+@BasePath('articles')
+export class PagedController extends BaseController {
+  @Get()
+  public async list(@Query() pagination: PaginationDTO) {
+    const limit = pagination?.limit && pagination.limit > 0 ? pagination.limit : 25;
+    const page = pagination?.page ?? 0;
+
+    const base = Article.select().where('Published', true);
+
+    // Clone BEFORE paging, so the count reflects the whole filtered set.
+    const total = await base.clone().selectCount();
+    const rows = await base.take(limit).skip(page * limit);
+
+    return new Ok({
+      Data: rows.map((r) => r.dehydrate()),
+      Total: total,
+      Page: page,
+      Limit: limit,
+    });
+  }
+}
+```
+
+`clone()` copies group-by statements too, which matters here — a cloned builder that silently
+lost its `GROUP BY` would report the wrong total.
+
+## `Model.all(page, perPage)`
+
+For a plain offset page with no extra conditions, the ORM's own static is shorter. Pages are
+zero-based, and paging is applied only when **both** arguments are valid.
+
+```ts sample
+import { Connection, Model, ModelBase, Primary } from '@spinajs/orm';
+
+@Connection('default')
+@Model('articles')
+export class Article extends ModelBase<Article> {
+  @Primary()
+  public Id: number;
+
+  public Title: string;
+}
+
+export async function page(n: number) {
+  return await Article.all(n, 25); // take(25).skip(n * 25)
+}
+```
+
+## Ordering across a relation
+
+`order`, `orderBy` and `orderByDescending` accept a dotted path, which populates the relation and
+sorts inside it.
+
+```ts sample
+import { Connection, Model, ModelBase, Primary, BelongsTo, SingleRelation } from '@spinajs/orm';
+
+@Connection('default')
+@Model('authors')
+export class Author extends ModelBase<Author> {
+  @Primary()
+  public Id: number;
+
+  public Name: string;
+}
+
+@Connection('default')
+@Model('articles')
+export class Article extends ModelBase<Article> {
+  @Primary()
+  public Id: number;
+
+  public author_id: number;
+
+  @BelongsTo(Author, 'author_id', 'Id')
+  public Author: SingleRelation<Author>;
+}
+
+export async function byAuthorName() {
+  return await Article.select().orderBy('Author.Name');
+}
+```
+
+## `ITransformOptions`
+
+A shape for handing paging metadata to a collection transformer. `@spinajs/orm-api` consumes it
+— see [its docs](../../orm-api/docs/05-transformers-and-policies.md).
+
+| Field | Meaning |
+| --- | --- |
+| `totalCount` | Rows matching before paging. |
+| `currentPage` | Zero-based page index. |
+| `perPage` | Page size. |
+| `order` | `SortOrder`. |
+| `orderBy` | Column name. |
+| `model` | The model class. |

--- a/packages/orm-http/docs/06-repository-middleware.md
+++ b/packages/orm-http/docs/06-repository-middleware.md
@@ -1,0 +1,176 @@
+# Repository middleware and responses
+
+## `RepositoryMiddleware` — currently unreachable
+
+> **Read this before designing around it.** The class exists in
+> [`src/middleware.ts`](../src/middleware.ts), but:
+>
+> - `src/index.ts` does not re-export it (it re-exports `interfaces`, `model`, `decorators`,
+>   `extension`, `route-arg`, `builders`, `dto`, `dto-relation` and
+>   `response-methods/OrmNotFound` — not `middleware.js`);
+> - `package.json` declares `"exports": { "." : ... }` only, so a deep import such as
+>   `@spinajs/orm-http/lib/mjs/middleware.js` does not resolve either;
+> - nothing in this repository invokes its hooks. `@spinajs/orm-api` carries an identical copy,
+>   equally unexported, and the generic CRUD controller the hooks were written for is commented
+>   out in that package.
+>
+> It is dead code today. Reaching it requires adding `export * from './middleware.js';` to
+> `src/index.ts` first. For interception that actually fires, use `QueryMiddleware` — see below.
+
+### The intended shape
+
+An abstract `AsyncService` whose methods all have empty defaults, so a subclass overrides only
+what it needs. Three families of hook:
+
+**`...Start` — before anything runs.** Async; throw to abort.
+
+| Hook | Arguments |
+| --- | --- |
+| `onGetMiddlewareStart(resource, req)` | Resource identifier and request. |
+| `onGetAllMiddlewareStart(req)` | |
+| `onInsertMiddlewareStart(data, req)` | The incoming `JsonApiIncomingObject`. |
+| `onUpdateMiddlewareStart(resource, data, req)` | |
+| `onDeleteMiddlewareStart(resource, req)` | |
+
+**`...Query` — amend the query.** Synchronous, receiving the builder before it executes.
+
+| Hook | Builder |
+| --- | --- |
+| `onGetMiddlewareQuery(query, model, req)` | `SelectQueryBuilder` |
+| `onGetAllMiddlewareQuery(query, model, req)` | `SelectQueryBuilder` |
+| `onInsertMiddlewareQuery(query, model, req)` | `InsertQueryBuilder` |
+| `onUpdateMiddlewareQuery(resource, query, model, req)` | `UpdateQueryBuilder` |
+| `onDeleteMiddlewareQuery(query, model, req)` | `DeleteQueryBuilder` |
+
+**`...Result` — reshape the response.** Synchronous, returning the payload.
+
+| Hook | Returns |
+| --- | --- |
+| `onGetMiddlewareResult(jsonData, req)` | The payload. |
+| `onGetAllMiddlewareResult(jsonData, req)` | |
+| `onInsertMiddlewareResult(jsonData, req)` | |
+| `onUpdateMiddlewareResult(jsonData, req)` | |
+| `onDeleteMiddlewareResult(req)` | Nothing. |
+
+Were it exported, a subclass would look like this — and a controller would have to resolve
+`Array.ofType(RepositoryMiddleware)` and call the hooks itself, since nothing does it for you:
+
+```ts
+@Injectable(RepositoryMiddleware)
+export class TenantScopeMiddleware extends RepositoryMiddleware {
+  public onGetAllMiddlewareQuery(query: SelectQueryBuilder<any>, _model: Constructor<ModelBase>, req: express.Request): void {
+    const tenantId = (req as any).Tenant?.Id;
+    if (tenantId !== undefined) {
+      query.andWhere('TenantId', tenantId);
+    }
+  }
+}
+```
+
+## `QueryMiddleware` — the mechanism that works
+
+Registered through DI in the core, and invoked by **every** builder on every connection, whatever
+code path created it. This is what to reach for.
+
+```ts sample
+import { Injectable } from '@spinajs/di';
+import { QueryMiddleware, QueryBuilder, QueryContext, InsertQueryBuilder } from '@spinajs/orm';
+
+@Injectable(QueryMiddleware)
+export class TenantScope extends QueryMiddleware {
+  /**
+   * Runs from the builder's CONSTRUCTOR, for every builder type. The right place to
+   * ADD a constraint; the wrong place to read the payload, which does not exist yet.
+   */
+  public afterQueryCreation(query: QueryBuilder): void {
+    if (query.QueryContext === QueryContext.Select || query.QueryContext === QueryContext.Update || query.QueryContext === QueryContext.Delete) {
+      (query as any).where('TenantId', 7);
+    }
+  }
+
+  /**
+   * Runs once per builder immediately before execution, with the query fully
+   * assembled. The right place to inspect or rewrite what is about to be written.
+   */
+  public beforeQueryExecution(query: QueryBuilder): void {
+    if (query instanceof InsertQueryBuilder) {
+      query.forceColumn('TenantId', 7);
+    }
+  }
+}
+```
+
+The two hooks differ in what the query is guaranteed to contain, and that difference is
+load-bearing rather than stylistic. A value written at construction would be overwritten by the
+caller's own `values()` call; a constraint added just before execution is fine either way. Full
+discussion in [the core's query-builder docs](../../orm/docs/06-query-builder.md#middleware).
+
+A middleware that throws from either hook aborts the query.
+
+## `ModelMiddleware`
+
+The core also offers a model-lifecycle abstraction with `onInsert`, `onUpdate`, `onDelete` and
+`onSelect`. Register subclasses under the `ModelMiddleware` token. See
+[11-converters-and-hydration.md](../../orm/docs/11-converters-and-hydration.md).
+
+## `OrmNotFound`
+
+```ts
+@HandleException([OrmNotFoundException])
+@Injectable(Response)
+export class OrmNotFound extends Response {
+  protected _errorCode = HTTP_STATUS_CODE.NOT_FOUND;
+  protected _template = 'notFound.pug';
+}
+```
+
+This one *is* exported and registers itself when the package is imported. Any
+`OrmNotFoundException` escaping a route becomes a `404` rendered through `notFound.pug`.
+
+`@FromModel()` and `@Relation()` both raise `OrmNotFoundException` on a miss, so a missing row is
+a `404` with nothing to write. `firstOrFail()` raises the same exception, so a hand-written query
+behaves identically:
+
+```ts sample
+import { BaseController, BasePath, Get, Ok, Param } from '@spinajs/http';
+import { Connection, Model, ModelBase, Primary } from '@spinajs/orm';
+
+@Connection('default')
+@Model('articles')
+export class Article extends ModelBase<Article> {
+  @Primary()
+  public Id: number;
+
+  public Slug: string;
+}
+
+@BasePath('articles')
+export class Controller extends BaseController {
+  @Get('by-slug/:slug')
+  public async bySlug(@Param() slug: string) {
+    // OrmNotFoundException -> 404. No try/catch needed.
+    const article = await Article.select().where('Slug', slug).firstOrFail();
+    return new Ok(article.dehydrate());
+  }
+}
+```
+
+Use `firstOrThrow(error)` when you want a different status or message; it accepts either an
+`Error` or a function receiving the compiled `ICompilerOutput`.
+
+## `JsonApiIncomingObject`
+
+The JSON:API request-body shape, `@Schema`-annotated against draft-07 and exported normally:
+
+```ts
+export class JsonApiIncomingObject {
+  public data: {
+    type: string;
+    id: string;
+    attributes: any;
+    relationships: any;
+  };
+}
+```
+
+The package also ships `src/schemas/json-api.json` for validating such bodies.

--- a/packages/orm-http/docs/README.md
+++ b/packages/orm-http/docs/README.md
@@ -1,0 +1,70 @@
+# `@spinajs/orm-http` documentation
+
+Glue between `@spinajs/orm` and `@spinajs/http`. It adds route-argument decorators that load or
+build models straight from a request, a declarative filtering layer, and DTO fields that resolve
+to database entities.
+
+It does **not** generate controllers or routes. You write ordinary `@spinajs/http` controllers;
+this package removes the boilerplate inside them.
+
+## Pages
+
+| | Page | Covers |
+| --- | --- | --- |
+| 01 | [Overview](01-overview.md) | What it adds, bootstrapping, the extension points |
+| 02 | [Route arguments](02-route-args.md) | `@FromModel`, `@AsModel`, `DbModelHydrator`, model params |
+| 03 | [Filtering](03-filtering.md) | `@Filterable`, `@Filter`, every operator, the generated schema |
+| 04 | [DTO relations](04-dto-relations.md) | `@Relation` on a DTO, `RelationResolverHydrator` |
+| 05 | [Pagination and ordering](05-pagination-and-order.md) | `PaginationDTO`, `OrderDTO` |
+| 06 | [Repository middleware](06-repository-middleware.md) | `RepositoryMiddleware`, error responses |
+
+## At a glance
+
+```ts sample
+import { BaseController, BasePath, Get, Ok, Query } from '@spinajs/http';
+import { Connection, Model, ModelBase, Primary } from '@spinajs/orm';
+import { FromModel, Filter, IFilterRequest } from '@spinajs/orm-http';
+import { Filterable } from '@spinajs/orm-http';
+
+@Connection('default')
+@Model('articles')
+export class Article extends ModelBase<Article> {
+  @Primary()
+  public Id: number;
+
+  @Filterable(['eq', 'like'])
+  public Title: string;
+
+  @Filterable(['eq', 'gt', 'lt'])
+  public Views: number;
+}
+
+@BasePath('articles')
+export class ArticleController extends BaseController {
+  /** GET /articles/:article — loaded by primary key, 404 when missing. */
+  @Get(':article')
+  public byId(@FromModel() article: Article) {
+    return new Ok(article.dehydrate());
+  }
+
+  /** GET /articles?filter={"op":"and","filters":[{"Column":"Title","Operator":"like","Value":"x"}]} */
+  @Get()
+  public async list(@Filter(Article) filter: IFilterRequest, @Query() _page: number) {
+    const rows = await Article.select().filter(filter.filters, filter.op);
+    return new Ok(rows.map((r) => r.dehydrate()));
+  }
+}
+```
+
+## Related
+
+- [`@spinajs/orm`](../../orm/docs/) — the core
+- [`@spinajs/orm-api`](../../orm-api/docs/) — CRUD controller building blocks built on the same ideas
+
+## A note on this package's tests
+
+`npm test` in this package currently fails during bootstrap with
+`No __file_provider_instance__ registered, make sure fs package is imported in your
+application` — the test harness does not register `@spinajs/fs`. That is a test-configuration
+gap, not a defect in the package. The behaviour documented here is read from the source and from
+the test fixtures.

--- a/packages/orm-http/package.json
+++ b/packages/orm-http/package.json
@@ -24,7 +24,7 @@
     "clean": "rimraf lib/ && rimraf tsconfig.tsbuildinfo",
     "test": "ts-mocha -p tsconfig.json test/**/*.test.ts",
     "coverage": "nyc npm run test",
-    "build-docs": "rimraf docs && typedoc --options typedoc.json src/",
+    "build-docs": "rimraf api-docs && typedoc --options typedoc.json src/",
     "format": "prettier --write \"src/**/*.ts\"",
     "lint": "eslint -c .eslintrc.cjs --ext .ts src --fix",
     "preversion": "npm run lint",

--- a/packages/orm-http/typedoc.json
+++ b/packages/orm-http/typedoc.json
@@ -1,6 +1,6 @@
 {
     "mode": "modules",
-    "out": "docs",
+    "out": "api-docs",
     "name": "spine",
     "theme": "default",
     "ignoreCompilerErrors": "true",

--- a/packages/orm-mssql/.gitignore
+++ b/packages/orm-mssql/.gitignore
@@ -61,6 +61,6 @@ jspm_packages/
 tsconfig.tsbuildinfo
 
 # doc
-docs
+api-docs
 
 lib

--- a/packages/orm-mssql/README.md
+++ b/packages/orm-mssql/README.md
@@ -1,11 +1,96 @@
-# `@spinajs/orm-sql`
+# `@spinajs/orm-mssql`
 
-> TODO: description
+The Microsoft SQL Server dialect driver for [`@spinajs/orm`](../orm), built on
+[`@spinajs/orm-sql`](../orm-sql).
+
+## Known defect: inserts fail
+
+**This driver registers no `ServerResponseMapper`.** Every driver must — the shape of an insert
+response is dialect-specific and the base class has no default. Any path that reads an insert
+response therefore throws:
+
+```
+no ServerResponseMapper is registered for this connection. Every driver must register one:
+container.register(MyMapper).as(ServerResponseMapper)
+```
+
+That covers `Model.insert()`, `model.insert()`, `model.save()` and every upsert. It reproduces
+from this package's own suite — `npm test` gives **10 passing, 2 failing**, both with that
+message.
+
+The fix is a mapper reading the `SELECT SCOPE_IDENTITY() as ID` that `MsSqlInsertQueryCompiler`
+already appends to every insert, registered in `resolve()`. See
+[docs/README.md](docs/README.md) for a working implementation.
+
+Until then, treat this driver as **read-capable only**. Selects, schema operations and
+transactions all work.
+
+## Install
+
+```bash
+npm install @spinajs/orm @spinajs/orm-mssql
+```
 
 ## Usage
 
-```
-const ormSql = require('@spinajs/orm-sql');
+```ts
+import { DI } from '@spinajs/di';
+import { Orm } from '@spinajs/orm';
+import { MsSqlOrmDriver } from '@spinajs/orm-mssql';
 
-// TODO: DEMONSTRATE API
+DI.register(MsSqlOrmDriver).as('orm-driver-mssql');
+await DI.resolve(Orm);
+```
+
+```ts
+// configuration
+{
+  db: {
+    DefaultConnection: 'mssql',
+    Connections: [
+      {
+        Name: 'mssql',
+        Driver: 'orm-driver-mssql',
+        Host: '127.0.0.1',
+        Port: 1433,
+        User: 'sa',
+        Password: 'Str0ng!Passw0rd',
+        Database: 'app',
+        Options: { Schema: 'dbo', encrypt: false, trustServerCertificate: true },
+      },
+    ],
+  },
+}
+```
+
+## What is distinctive
+
+- **`AliasSeparator` defaults to `#`, not `$`** — `$` begins a pseudo-column in T-SQL.
+- **Backticks are stripped** from every statement before it is sent, since T-SQL quotes with
+  `[brackets]`.
+- **Three-part table names** — `[database].[schema].[table]`, via `Options.Schema`.
+- **`OFFSET ... FETCH NEXT`** instead of `LIMIT`. It is emitted only when a limit is set, so
+  `skip()` without `take()` applies no offset — and T-SQL requires an `ORDER BY` before `OFFSET`.
+- **`DELETE TOP (n)`** for limited deletes.
+- **`INSERT IGNORE` throws** — `InsertBehaviour.InsertOrIgnore` is unsupported.
+- **Multi-column `ORDER BY` is reduced to one column.**
+- **No native `SET`, `ENUM` or `JSON`**, so `whereInSet` / `whereNotInSet` do not work here and
+  `@Json()` is required for JSON columns.
+- **DDL *is* transactional**, unlike MySQL — `Migration.Transaction.Mode = PerMigration` gives a
+  genuinely atomic migration.
+
+## Documentation
+
+Full documentation lives in **[docs/](docs/)**.
+
+| | Page |
+| --- | --- |
+| 01 | [Configuration](docs/01-configuration.md) |
+| 02 | [Dialect notes](docs/02-dialect-notes.md) |
+
+## Development
+
+```bash
+npm test        # 10 passing, 2 failing — see the defect above
+npm run build
 ```

--- a/packages/orm-mssql/docs/01-configuration.md
+++ b/packages/orm-mssql/docs/01-configuration.md
@@ -1,0 +1,225 @@
+# Configuration
+
+## Options
+
+| Option | Meaning |
+| --- | --- |
+| `Name` | Connection name — what `@Connection('...')` refers to. |
+| `Driver` | `orm-driver-mssql`, matching the DI registration. |
+| `Host`, `Port` | Server address. SQL Server's default port is 1433. |
+| `User`, `Password` | Credentials. `Password` is never logged. |
+| `Database` | Database name — the first part of the three-part table name. |
+| `Pool.*` | `Min`, `Max`, `IdleTimeout`, `AcquireTimeout`. |
+| `Resilience.*` | Health-check interval and retry policy. |
+| `Migration.*` | `OnStartup`, `Table`, `Transaction.Mode`. |
+| `Options` | Passed through to the `mssql` package, **plus** `Schema` (see below). |
+| `AliasSeparator` | Defaults to **`#`** here, not `$`. |
+
+```ts sample
+import { FrameworkConfiguration } from '@spinajs/configuration';
+import { MigrationTransactionMode } from '@spinajs/orm';
+import _ from 'lodash';
+
+export class AppConfiguration extends FrameworkConfiguration {
+  public async resolve(): Promise<void> {
+    await super.resolve();
+
+    this.Config = _.merge(this.Config, {
+      db: {
+        DefaultConnection: 'mssql',
+        Connections: [
+          {
+            Name: 'mssql',
+            Driver: 'orm-driver-mssql',
+            Host: '127.0.0.1',
+            Port: 1433,
+            User: 'sa',
+            Password: 'Str0ng!Passw0rd',
+            Database: 'app',
+            Pool: { Min: 2, Max: 20, IdleTimeout: 30000, AcquireTimeout: 10000 },
+            Resilience: { HealthCheckInterval: 30000, MaxRetries: 5 },
+            Migration: {
+              OnStartup: true,
+              Transaction: { Mode: MigrationTransactionMode.PerMigration },
+            },
+            Options: {
+              // Driver-specific: the schema used to qualify every table.
+              Schema: 'dbo',
+              // Passed straight to the `mssql` package.
+              encrypt: true,
+              trustServerCertificate: false,
+              requestTimeout: 30000,
+            },
+          },
+        ],
+      },
+    });
+  }
+}
+```
+
+## `Options.Schema`
+
+`MsSqlTableAliasCompiler` builds a **three-part** name:
+
+```sql
+[database].[schema].[table] as [alias]
+```
+
+- `[database]` appears when the builder has one (from `Database`, or `database()` on the builder).
+- `[schema]` appears when `Options.Schema` is set.
+- The alias appears when the builder has one.
+
+Set `Options.Schema: 'dbo'` unless your objects live elsewhere. Without it, tables resolve
+against the connection's default schema, which is usually but not always what you want.
+
+## `AliasSeparator`
+
+The driver overrides the default in its constructor:
+
+```ts
+constructor(options: IDriverOptions) {
+  super(Object.assign({ AliasSeparator: '#' }, options));
+}
+```
+
+`$` is the framework-wide default, but it begins a pseudo-column in T-SQL, so generated aliases
+would be invalid. Generated aliases here look like `#users#`.
+
+Override it only if `#` collides with something in your schema.
+
+## Backtick stripping
+
+`executeOnDb` runs `stmt.replaceAll('`', '')` before sending anything to the server. The generic
+SQL layer quotes identifiers with backticks — MySQL's convention — and T-SQL uses `[brackets]`,
+so the backticks are removed wholesale rather than translated.
+
+The practical consequence: **a backtick inside a string literal in a raw query will be stripped
+too.** Bind values as parameters rather than interpolating them, which is what the builders do
+anyway.
+
+## Pooling
+
+A real pool of read-write connections, backed by the `mssql` package's `ConnectionPool`.
+
+| Option | Default |
+| --- | --- |
+| `Pool.Min` | `0` |
+| `Pool.Max` | `10` |
+| `Pool.IdleTimeout` | `30000` |
+| `Pool.AcquireTimeout` | `10000` |
+
+`PoolLimit` remains honoured when `Pool.Max` is absent.
+
+## Transactions
+
+Pooled, so `_begin` acquires a connection onto `ctx.connection` and `_dispose` releases it.
+Statements inside the callback pick the transaction's request up from the context — only this
+driver's `_begin` populates it, so nothing outside a transaction is affected.
+
+All four isolation levels are declared:
+
+```ts
+public readonly SupportedIsolationLevels: IsolationLevel[] = [
+  'READ UNCOMMITTED', 'READ COMMITTED', 'REPEATABLE READ', 'SERIALIZABLE',
+];
+```
+
+```ts sample
+import { DI } from '@spinajs/di';
+import { OrmDriver } from '@spinajs/orm';
+
+export async function isolated() {
+  const driver = DI.resolve<OrmDriver>('OrmConnection', ['mssql'])!;
+
+  return await driver.transaction(
+    async () => driver.select().from('ledger').where('Posted', false),
+    { isolation: 'SERIALIZABLE' },
+  );
+}
+```
+
+Nesting takes savepoints, so `save()` and nested `transaction()` calls compose.
+
+Unlike MySQL, **SQL Server DDL *is* transactional** — `CREATE TABLE` and `ALTER TABLE` roll back
+with the transaction. `Migration.Transaction.Mode = PerMigration` therefore gives a genuinely
+atomic migration here.
+
+## Encryption
+
+The `mssql` package defaults to encrypted connections against Azure. For a local server with a
+self-signed certificate:
+
+```ts sample
+import { FrameworkConfiguration } from '@spinajs/configuration';
+import _ from 'lodash';
+
+export class LocalConfiguration extends FrameworkConfiguration {
+  public async resolve(): Promise<void> {
+    await super.resolve();
+
+    this.Config = _.merge(this.Config, {
+      db: {
+        Connections: [
+          {
+            Name: 'mssql',
+            Driver: 'orm-driver-mssql',
+            Host: '127.0.0.1',
+            Port: 1433,
+            User: 'sa',
+            Password: 'Str0ng!Passw0rd',
+            Database: 'app',
+            Options: {
+              Schema: 'dbo',
+              encrypt: false,
+              trustServerCertificate: true,
+            },
+          },
+        ],
+      },
+    });
+  }
+}
+```
+
+Do not carry `trustServerCertificate: true` into production — it disables certificate validation.
+
+## Named instances
+
+Reach a named instance through `Options.instanceName`, which the `mssql` package understands:
+
+```ts sample
+import { FrameworkConfiguration } from '@spinajs/configuration';
+import _ from 'lodash';
+
+export class NamedInstanceConfiguration extends FrameworkConfiguration {
+  public async resolve(): Promise<void> {
+    await super.resolve();
+
+    this.Config = _.merge(this.Config, {
+      db: {
+        Connections: [
+          {
+            Name: 'mssql',
+            Driver: 'orm-driver-mssql',
+            Host: 'db-server',
+            User: 'app',
+            Password: 'secret',
+            Database: 'app',
+            Options: {
+              Schema: 'dbo',
+              instanceName: 'SQLEXPRESS',
+              // The SQL Browser service resolves the port; omit Port entirely.
+            },
+          },
+        ],
+      },
+    });
+  }
+}
+```
+
+## Before you write
+
+See the [README](README.md): this driver registers no `ServerResponseMapper`, so every insert
+path throws. Selects, schema operations and transactions work.

--- a/packages/orm-mssql/docs/02-dialect-notes.md
+++ b/packages/orm-mssql/docs/02-dialect-notes.md
@@ -1,0 +1,185 @@
+# Dialect notes
+
+## Feature support
+
+```ts
+public supportedFeatures(): ISupportedFeature {
+  return { events: true, insertReturning: false, insertIdIsFirstOfBatch: false };
+}
+```
+
+| Feature | Value | Consequence |
+| --- | --- | --- |
+| `events` | `true` | Scheduled jobs are declared supported. |
+| `insertReturning` | `false` | `returning()` throws `NotSupported`. |
+| `insertIdIsFirstOfBatch` | `false` | `SCOPE_IDENTITY()` reports the **last** identity generated in the scope, so a multi-row insert cannot be walked forwards from it. MSSQL opts out of the positional batch backfill. |
+
+All four isolation levels are declared.
+
+## Compiler overrides
+
+More than any other driver — T-SQL diverges from the generic layer in several places.
+
+| Token | Implementation | Reason |
+| --- | --- | --- |
+| `TableExistsCompiler` | `MsSqlTableExistsCompiler` | Queries `sys.tables` / `INFORMATION_SCHEMA`. |
+| `LimitQueryCompiler` | `MsSqlLimitCompiler` | `OFFSET ... FETCH NEXT` instead of `LIMIT`. |
+| `OrderByQueryCompiler` | `MsSqlOrderByCompiler` | Bracket quoting. |
+| `TableQueryCompiler` | `MsSqlTableQueryCompiler` | Table-level `UNIQUE(...)` constraints. |
+| `ColumnQueryCompiler` | `MsSqlColumnQueryCompiler` | `IDENTITY(1,1)`, T-SQL types. |
+| `InsertQueryCompiler` | `MsSqlInsertQueryCompiler` | `SELECT SCOPE_IDENTITY()`, upsert shape. |
+| `DeleteQueryCompiler` | `MsSqlDeleteQueryCompiler` | `DELETE TOP (n)`. |
+| `OnDuplicateQueryCompiler` | `MsSqlOnDuplicateQueryCompiler` | `MERGE`-style upsert. |
+| `TableAliasCompiler` | `MsSqlTableAliasCompiler` | Three-part names. |
+| `DatetimeValueConverter` | `MsSqlDatetimeValueConverter` | T-SQL datetime formats. |
+| `ModelDehydrator` | `MssqlModelDehydrator` | Value shaping on the way out. |
+
+Notably **absent**: `ServerResponseMapper`. See the [README](README.md).
+
+## Paging
+
+`MsSqlLimitCompiler` emits the T-SQL form:
+
+```sql
+OFFSET ? ROWS FETCH NEXT ? ROWS ONLY
+```
+
+Two consequences that differ from every other driver:
+
+**The clause is emitted only when `limit > 0`.** A `skip()` with no `take()` produces nothing at
+all — no offset is applied. The generic compiler handles that case with a
+`LIMIT 18446744073709551615` stand-in; this one does not. Always pair `skip()` with `take()`.
+
+**T-SQL requires `ORDER BY` before `OFFSET`.** A paged query without a sort is a syntax error at
+the server, so add one:
+
+```ts sample
+import { Connection, Model, ModelBase, Primary } from '@spinajs/orm';
+
+@Connection('mssql')
+@Model('articles')
+export class Article extends ModelBase<Article> {
+  @Primary()
+  public Id: number;
+
+  public Title: string;
+}
+
+export async function paged(page: number) {
+  // ORDER BY is mandatory for OFFSET/FETCH on SQL Server.
+  return await Article.select().orderBy('Id').take(25).skip(page * 25);
+}
+```
+
+## `ORDER BY`
+
+`MsSqlOrderByCompiler` emits **only the first sort entry** — it calls `getSort()`, not
+`getSorts()`. Multi-column ordering is silently reduced to one column, the same limitation SQLite
+has. Use a `RawQuery` when you need more.
+
+## Limited deletes
+
+`DELETE` has no `LIMIT` in T-SQL, so `MsSqlDeleteQueryCompiler` emits `DELETE TOP (n) FROM ...`
+when the builder carries a limit.
+
+## Inserts
+
+`MsSqlInsertQueryCompiler` appends an identity read to every insert:
+
+```sql
+INSERT INTO [db].[dbo].[articles] ([Title]) VALUES (?); SELECT SCOPE_IDENTITY() as ID;
+```
+
+`SCOPE_IDENTITY()` is scoped to the current statement batch, so it is not affected by triggers
+inserting elsewhere — but it reports the **last** identity generated, which is why
+`insertIdIsFirstOfBatch` is false.
+
+Reading that `ID` back is precisely the job of the missing `ServerResponseMapper`.
+
+### `INSERT IGNORE` is not supported
+
+```ts
+if (this._builder.Ignore) {
+  throw new OrmException(`mssql insert or ignore is not supported`);
+}
+```
+
+So `InsertBehaviour.InsertOrIgnore` throws on this driver. Use `InsertOrUpdate`, or guard with an
+`exists()` check.
+
+`InsertBehaviour.InsertOrReplace` has no T-SQL equivalent either — `MsSqlOnDuplicateQueryCompiler`
+implements upsert as a `MERGE`-shaped statement, which is what `InsertOrUpdate` maps onto.
+
+## Table creation
+
+`MsSqlTableQueryCompiler` emits table-level `UNIQUE(...)` constraints rather than inline `UNIQUE`
+column modifiers, collecting every column flagged unique into one clause.
+
+Auto-increment is `IDENTITY(1,1)`, so `table.increments('Id')` and
+`table.int('Id').autoIncrement()` both produce an identity column.
+
+## Type mapping
+
+`MsSqlColumnQueryCompiler` maps onto T-SQL types. The important divergences from the generic
+mapping:
+
+| ORM type | T-SQL |
+| --- | --- |
+| `string` | `NVARCHAR(n)` |
+| `text`, `longtext`, … | `NVARCHAR(MAX)` |
+| `boolean` | `BIT` |
+| `dateTime` | `DATETIME2` |
+| `binary`, blobs | `VARBINARY` |
+| `json` | `NVARCHAR(MAX)` — no native JSON column type |
+| `enum` | A string column plus a `CHECK` constraint — no native `ENUM` |
+| `set` | A string column — no native `SET` |
+
+Two things follow.
+
+**`whereInSet` / `whereNotInSet` do not work as written.** They compile to `FIND_IN_SET`, which is
+MySQL-only. Model set columns as a related table on this dialect.
+
+**`@Json()` is required for JSON columns.** There is no native JSON type to auto-detect, so the
+decorator is what attaches `JsonValueConverter`.
+
+## Datetimes
+
+`MsSqlDatetimeValueConverter` handles the `DATETIME2` round-trip, replacing the generic
+`SqlDatetimeValueConverter`. `@spinajs/orm`'s `IDehydrateOptions.dateTimeFormat` (`'iso'`,
+`'sql'`, `'unix'`) is honoured.
+
+## `MssqlModelDehydrator`
+
+Registered over `StandardModelDehydrator`, shaping values on the way out for T-SQL's stricter
+parameter typing. It is a dialect detail rather than something to configure.
+
+## Transactions and DDL
+
+Unlike MySQL, SQL Server DDL is fully transactional. `Migration.Transaction.Mode = PerMigration`
+gives a genuinely atomic migration — a failure halfway through rolls the whole schema change
+back.
+
+## `tableInfo`
+
+Reflection queries `INFORMATION_SCHEMA`, scoped by `Database` and `Options.Schema`, populating
+`Name`, `Type`, `NativeType`, `MaxLength`, `Nullable`, `DefaultValue`, `PrimaryKey`,
+`AutoIncrement` (from `IS_IDENTITY`) and `Unique`.
+
+## Summary
+
+| Behaviour | MSSQL |
+| --- | --- |
+| `ServerResponseMapper` | **Missing — inserts throw** |
+| `RETURNING` | Not supported — throws |
+| Batch key backfill | Not supported (`SCOPE_IDENTITY()` is the last id) |
+| `INSERT IGNORE` | Throws |
+| Upsert | `MERGE`-shaped, via `InsertOrUpdate` |
+| Paging | `OFFSET/FETCH`; requires `ORDER BY`; `skip()` alone does nothing |
+| Multi-column `ORDER BY` | Reduced to one column |
+| Limited delete | `DELETE TOP (n)` |
+| Identifier quoting | Backticks stripped; `[brackets]` emitted |
+| Alias separator | `#` |
+| Table naming | `[database].[schema].[table]` |
+| Native `SET` / `ENUM` / `JSON` | None |
+| DDL in a transaction | **Yes** |
+| Isolation levels | All four |

--- a/packages/orm-mssql/docs/README.md
+++ b/packages/orm-mssql/docs/README.md
@@ -1,0 +1,106 @@
+# `@spinajs/orm-mssql` documentation
+
+The Microsoft SQL Server dialect driver, built on [`@spinajs/orm-sql`](../../orm-sql/docs/).
+
+| | Page | Covers |
+| --- | --- | --- |
+| 01 | [Configuration](01-configuration.md) | Connection options, schemas, pooling |
+| 02 | [Dialect notes](02-dialect-notes.md) | Feature support, T-SQL differences, compiler overrides |
+
+## Known defect: inserts fail
+
+**`MsSqlOrmDriver` does not register a `ServerResponseMapper`.** Every driver must — the shape of
+an insert response is dialect-specific and the base class has no default. Any code path that
+reads an insert response therefore throws:
+
+```
+no ServerResponseMapper is registered for this connection. Every driver must register one:
+container.register(MyMapper).as(ServerResponseMapper)
+```
+
+That covers `Model.insert()`, `model.insert()`, `model.save()` and every upsert. It is
+reproducible from this package's own suite:
+
+```
+cd packages/orm-mssql && npm test
+→ 10 passing, 2 failing — both with the message above
+```
+
+The fix is a mapper reading the `SELECT SCOPE_IDENTITY() as ID` that
+`MsSqlInsertQueryCompiler` already appends to every insert, registered in `resolve()`:
+
+```ts
+export class MsSqlServerResponseMapper extends ServerResponseMapper {
+  public read(data: any, _pkNames?: string[]) {
+    const id = Array.isArray(data) ? data[data.length - 1]?.ID : data?.ID;
+
+    return {
+      RowsAffected: data?.rowsAffected?.[0] ?? (Array.isArray(data) ? data.length : 0),
+      LastInsertId: typeof id === 'number' ? id : 0,
+      Returning: [] as any[],
+    };
+  }
+}
+
+// in MsSqlOrmDriver.resolve(), after super.resolve()
+this.Container.register(MsSqlServerResponseMapper).as(ServerResponseMapper);
+```
+
+Until that lands, treat this driver as **read-capable only**. Selects, schema operations and
+transactions all work.
+
+## Quick start
+
+```bash
+npm install @spinajs/orm @spinajs/orm-mssql
+```
+
+```ts sample
+import { DI } from '@spinajs/di';
+import { Orm } from '@spinajs/orm';
+import { MsSqlOrmDriver } from '@spinajs/orm-mssql';
+
+export async function bootstrap() {
+  DI.register(MsSqlOrmDriver).as('orm-driver-mssql');
+  return await DI.resolve(Orm);
+}
+```
+
+```ts sample
+import { FrameworkConfiguration } from '@spinajs/configuration';
+import _ from 'lodash';
+
+export class AppConfiguration extends FrameworkConfiguration {
+  public async resolve(): Promise<void> {
+    await super.resolve();
+
+    this.Config = _.merge(this.Config, {
+      db: {
+        DefaultConnection: 'mssql',
+        Connections: [
+          {
+            Name: 'mssql',
+            Driver: 'orm-driver-mssql',
+            Host: '127.0.0.1',
+            Port: 1433,
+            User: 'sa',
+            Password: 'Str0ng!Passw0rd',
+            Database: 'app',
+            Options: { Schema: 'dbo', encrypt: false, trustServerCertificate: true },
+          },
+        ],
+      },
+    });
+  }
+}
+```
+
+## What is distinctive here
+
+- **`AliasSeparator` defaults to `#`, not `$`.** `$` begins a pseudo-column in T-SQL, so the
+  driver overrides it in its constructor.
+- **Backticks are stripped** from every statement in `executeOnDb`, since T-SQL does not use them
+  for quoting.
+- **A three-part table name** — `database.schema.table` — via `Options.Schema`.
+- **`OFFSET ... FETCH NEXT`** instead of `LIMIT`, and `DELETE TOP (n)` for limited deletes.
+- **No `INSERT IGNORE`** — `orIgnore()` throws.

--- a/packages/orm-mssql/package.json
+++ b/packages/orm-mssql/package.json
@@ -24,7 +24,7 @@
     "clean": "rimraf lib/ && rimraf tsconfig.tsbuildinfo",
     "test": "ts-mocha -p tsconfig.json test/**/*.test.ts",
     "coverage": "nyc npm run test",
-    "build-docs": "rimraf docs && typedoc --options typedoc.json src/",
+    "build-docs": "rimraf api-docs && typedoc --options typedoc.json src/",
     "format": "prettier --write \"src/**/*.ts\"",
     "lint": "eslint -c .eslintrc.cjs --ext .ts src --fix",
     "preversion": "npm run lint",

--- a/packages/orm-mssql/typedoc.json
+++ b/packages/orm-mssql/typedoc.json
@@ -1,6 +1,6 @@
 {
     "mode": "modules",
-    "out": "docs",
+    "out": "api-docs",
     "name": "spine",
     "theme": "default",
     "ignoreCompilerErrors": "true",

--- a/packages/orm-mysql/.gitignore
+++ b/packages/orm-mysql/.gitignore
@@ -61,6 +61,6 @@ jspm_packages/
 tsconfig.tsbuildinfo
 
 # doc
-docs
+api-docs
 
 lib

--- a/packages/orm-mysql/README.md
+++ b/packages/orm-mysql/README.md
@@ -1,11 +1,103 @@
-# `orm-mysql`
+# `@spinajs/orm-mysql`
 
-> TODO: description
+The MySQL / MariaDB dialect driver for [`@spinajs/orm`](../orm), built on
+[`@spinajs/orm-sql`](../orm-sql). Ships two drivers: `MySqlOrmDriver`, and `MySqlSSHOrmDriver`
+which tunnels the connection over SSH.
+
+## Install
+
+```bash
+npm install @spinajs/orm @spinajs/orm-mysql
+```
 
 ## Usage
 
-```
-const ormMysql = require('orm-mysql');
+```ts
+import { DI } from '@spinajs/di';
+import { Orm } from '@spinajs/orm';
+import { MySqlOrmDriver } from '@spinajs/orm-mysql';
 
-// TODO: DEMONSTRATE API
+DI.register(MySqlOrmDriver).as('orm-driver-mysql');
+await DI.resolve(Orm);
 ```
+
+```ts
+// configuration
+{
+  db: {
+    DefaultConnection: 'mysql',
+    Connections: [
+      {
+        Name: 'mysql',
+        Driver: 'orm-driver-mysql',
+        Host: '127.0.0.1',
+        Port: 3306,
+        User: 'app',
+        Password: 'secret',
+        Database: 'app',
+        Encoding: 'utf8mb4',
+        Pool: { Min: 2, Max: 20 },
+        Migration: { OnStartup: true },
+      },
+    ],
+  },
+}
+```
+
+## What is distinctive
+
+- **`insertIdIsFirstOfBatch: true`** — the only driver where it holds. For a *simple* insert
+  (`INSERT ... VALUES (...), (...)`, the only shape the builder produces) InnoDB reserves one
+  contiguous block of auto-increment values and `LAST_INSERT_ID()` reports the first, so a
+  multi-row insert's keys can be read as `LAST_INSERT_ID() + index`. The ORM applies six guards
+  before relying on it.
+- **No `RETURNING`** — `InsertQueryBuilder.returning()` throws `NotSupported` rather than
+  silently doing nothing.
+- **Database events are supported**, and **all four isolation levels** are honoured.
+- **Retries are suppressed inside a transaction** — replaying a statement after reconnecting
+  would apply it outside the transaction.
+- **DDL is not transactional.** `Migration.Transaction.Mode = PerMigration` cannot roll back a
+  `CREATE TABLE`.
+
+Only two compiler overrides are needed (`TableExistsCompiler`, `ServerResponseMapper`), which is
+a fair measure of how closely the generic SQL layer tracks MySQL.
+
+## SSH tunnelling
+
+```ts
+DI.register(MySqlSSHOrmDriver).as('orm-driver-mysql-ssh');
+```
+
+```ts
+{
+  Name: 'remote',
+  Driver: 'orm-driver-mysql-ssh',
+  Host: '10.0.0.5', Port: 3306,
+  User: 'app', Password: 'secret', Database: 'app',
+  SSH: { Host: 'bastion.example.com', Port: 22, User: 'deploy', PrivateKey: '/home/deploy/.ssh/id_rsa' },
+}
+```
+
+The forward uses local port `12345`, so a second tunnelled connection in the same process will
+collide, and the private key must be unencrypted.
+
+## Documentation
+
+Full documentation lives in **[docs/](docs/)**.
+
+| | Page |
+| --- | --- |
+| 01 | [Configuration](docs/01-configuration.md) |
+| 02 | [Dialect notes](docs/02-dialect-notes.md) |
+
+## Development
+
+```bash
+npm test                                   # unit suite, no server needed
+
+docker compose --profile test up -d mysql  # from the repo root
+npm run test:integration
+```
+
+The container publishes MySQL on host port **3900**, deliberately not 3306, so it cannot collide
+with a locally installed MySQL. See the [repository README](../../README.md).

--- a/packages/orm-mysql/docs/01-configuration.md
+++ b/packages/orm-mysql/docs/01-configuration.md
@@ -1,0 +1,244 @@
+# Configuration
+
+## Options
+
+| Option | Meaning |
+| --- | --- |
+| `Name` | Connection name — what `@Connection('...')` refers to. |
+| `Driver` | `orm-driver-mysql`, or `orm-driver-mysql-ssh` for the tunnelling variant. |
+| `Host`, `Port` | Server address. Port defaults to MySQL's own default when omitted. |
+| `User`, `Password` | Credentials. `Password` is never logged. |
+| `Database` | Schema name. Used to qualify generated SQL and to scope `tableInfo`. |
+| `Encoding` | Connection charset, e.g. `utf8mb4`. |
+| `Pool.*` | `Min`, `Max`, `IdleTimeout`, `AcquireTimeout`. |
+| `Resilience.*` | Health-check interval and retry policy. |
+| `Migration.*` | `OnStartup`, `Table`, `Transaction.Mode`. |
+| `Options` | Passed through to `mysql2` untouched — TLS, timezone, and anything else. |
+| `SSH` | Tunnel settings, for `MySqlSSHOrmDriver` only. |
+| `AliasSeparator` | Defaults to `$`, which MySQL accepts. |
+
+```ts sample
+import { FrameworkConfiguration } from '@spinajs/configuration';
+import { MigrationTransactionMode } from '@spinajs/orm';
+import _ from 'lodash';
+
+export class AppConfiguration extends FrameworkConfiguration {
+  public async resolve(): Promise<void> {
+    await super.resolve();
+
+    this.Config = _.merge(this.Config, {
+      db: {
+        DefaultConnection: 'mysql',
+        Connections: [
+          {
+            Name: 'mysql',
+            Driver: 'orm-driver-mysql',
+            Host: '127.0.0.1',
+            Port: 3306,
+            User: 'app',
+            Password: 'secret',
+            Database: 'app',
+            Encoding: 'utf8mb4',
+            Pool: { Min: 2, Max: 20, IdleTimeout: 30000, AcquireTimeout: 10000 },
+            Resilience: { HealthCheckInterval: 30000, MaxRetries: 5, RetryDelay: 200, MaxRetryDelay: 5000 },
+            Migration: {
+              OnStartup: true,
+              Table: 'spinajs_migration',
+              Transaction: { Mode: MigrationTransactionMode.PerMigration },
+            },
+            Options: {
+              timezone: 'Z',
+              supportBigNumbers: true,
+              bigNumberStrings: false,
+            },
+          },
+        ],
+      },
+    });
+  }
+}
+```
+
+## Pooling
+
+Unlike SQLite, this is a real connection pool of read-write connections, backed by `mysql2`.
+
+| Option | Default | Meaning |
+| --- | --- | --- |
+| `Pool.Min` | `0` | Connections kept open while idle. |
+| `Pool.Max` | `10` | Maximum concurrent connections. |
+| `Pool.IdleTimeout` | `30000` | Milliseconds an idle connection is kept. |
+| `Pool.AcquireTimeout` | `10000` | Milliseconds to wait for a free connection. |
+
+The deprecated `PoolLimit` is still honoured when `Pool.Max` is absent, in the order
+`Pool.Max` → `PoolLimit` → `10`.
+
+`poolMetrics()` reports real numbers here, and the driver records acquire latency into the
+`orm_pool_acquire_seconds` histogram. See
+[the core's observability page](../../orm/docs/13-observability.md).
+
+Size `Pool.Max` against the server's `max_connections`, remembering that every process instance
+opens its own pool.
+
+## Transactions
+
+A pooled driver, so `_begin` **acquires a connection** and puts it on `ctx.connection`, and
+`_dispose` releases it. Every statement issued inside the callback runs on that connection —
+the context is carried through `AsyncLocalStorage`, so nothing has to be threaded by hand.
+
+All four isolation levels are declared:
+
+```ts
+public readonly SupportedIsolationLevels: IsolationLevel[] = [
+  'READ UNCOMMITTED', 'READ COMMITTED', 'REPEATABLE READ', 'SERIALIZABLE',
+];
+```
+
+```ts sample
+import { DI } from '@spinajs/di';
+import { OrmDriver } from '@spinajs/orm';
+
+export async function isolated() {
+  const driver = DI.resolve<OrmDriver>('OrmConnection', ['mysql'])!;
+
+  return await driver.transaction(
+    async () => driver.select().from('ledger').where('Posted', false),
+    { isolation: 'REPEATABLE READ' },
+  );
+}
+```
+
+Nesting takes savepoints, so `save()`, `Relation.sync()` and your own nested `transaction()`
+calls compose correctly.
+
+## Retries
+
+`executeOnDb` wraps every statement in `withReconnect`. Reads *and* writes are both retried,
+because `withReconnect` only re-runs on transport failures — where the statement provably never
+reached the server.
+
+The driver adds one rule of its own:
+
+```ts
+protected isRetryableError(err: unknown): boolean {
+  // Inside a transaction the connection carried uncommitted state. Reconnecting and
+  // replaying one statement would silently apply it OUTSIDE the transaction.
+  if (this.TransactionStorage.getStore()) {
+    return false;
+  }
+  // ... plus the mysql2 protocol codes
+}
+```
+
+Retryable codes relevant here include `PROTOCOL_CONNECTION_LOST`, `PROTOCOL_SEQUENCE_TIMEOUT`,
+`PROTOCOL_ENQUEUE_AFTER_FATAL_ERROR`, `PROTOCOL_ENQUEUE_AFTER_QUIT`, `ER_CON_COUNT_ERROR` and
+`ER_LOCK_WAIT_TIMEOUT`, alongside the Node socket errors.
+
+## Health checks
+
+`connect()` takes and releases a real connection, so it genuinely verifies the link — which is
+why this driver may promote itself back to `Connected` on a successful reconnect rather than
+waiting for the next probe.
+
+## SSH tunnelling
+
+`MySqlSSHOrmDriver` opens an SSH connection and forwards the MySQL port through it. Register it
+under its own driver name:
+
+```ts sample
+import { DI } from '@spinajs/di';
+import { Orm } from '@spinajs/orm';
+import { MySqlSSHOrmDriver } from '@spinajs/orm-mysql';
+
+export async function bootstrap() {
+  DI.register(MySqlSSHOrmDriver).as('orm-driver-mysql-ssh');
+  return await DI.resolve(Orm);
+}
+```
+
+```ts sample
+import { FrameworkConfiguration } from '@spinajs/configuration';
+import _ from 'lodash';
+
+export class TunnelledConfiguration extends FrameworkConfiguration {
+  public async resolve(): Promise<void> {
+    await super.resolve();
+
+    this.Config = _.merge(this.Config, {
+      db: {
+        Connections: [
+          {
+            Name: 'remote',
+            Driver: 'orm-driver-mysql-ssh',
+            // Host/Port as seen FROM the bastion — usually the database's private address.
+            Host: '10.0.0.5',
+            Port: 3306,
+            User: 'app',
+            Password: 'secret',
+            Database: 'app',
+            SSH: {
+              Host: 'bastion.example.com',
+              Port: 22,
+              User: 'deploy',
+              PrivateKey: '/home/deploy/.ssh/id_rsa',
+            },
+          },
+        ],
+      },
+    });
+  }
+}
+```
+
+`resolve()` validates the configuration before any connection is attempted:
+
+- `SSH options are not set for MySqlSSHOrmDriver` when `SSH` is absent;
+- `SSH private key file X does not exist` when the key file is missing — checked with
+  `fs.existsSync`.
+
+`disconnect()` ends the SSH client after closing the pool.
+
+Two operational notes: the forward is set up from local port `12345`, so a second tunnelled
+connection in the same process will collide; and the private key must be unencrypted, since no
+passphrase option is exposed.
+
+## Migrations
+
+`Migration.Transaction.Mode = PerMigration` wraps each migration in a transaction. Be aware that
+**MySQL DDL is not transactional** — `CREATE TABLE`, `ALTER TABLE` and friends commit
+implicitly, so a migration that fails halfway leaves earlier DDL applied. Keep migrations small
+and idempotent-friendly rather than relying on rollback.
+
+The migration table defaults to `spinajs_migration` and is created automatically.
+
+## Environment-driven configuration
+
+`@spinajs/configuration` resolves placeholders in string values, so credentials can come from
+the environment rather than the file:
+
+```ts sample
+import { FrameworkConfiguration } from '@spinajs/configuration';
+import _ from 'lodash';
+
+export class EnvConfiguration extends FrameworkConfiguration {
+  public async resolve(): Promise<void> {
+    await super.resolve();
+
+    this.Config = _.merge(this.Config, {
+      db: {
+        Connections: [
+          {
+            Name: 'mysql',
+            Driver: 'orm-driver-mysql',
+            Host: process.env.DB_HOST ?? '127.0.0.1',
+            Port: Number(process.env.DB_PORT ?? 3306),
+            User: process.env.DB_USER ?? 'app',
+            Password: process.env.DB_PASSWORD ?? '',
+            Database: process.env.DB_NAME ?? 'app',
+          },
+        ],
+      },
+    });
+  }
+}
+```

--- a/packages/orm-mysql/docs/02-dialect-notes.md
+++ b/packages/orm-mysql/docs/02-dialect-notes.md
@@ -1,0 +1,233 @@
+# Dialect notes
+
+## Feature support
+
+```ts
+public supportedFeatures(): ISupportedFeature {
+  return { events: true, insertReturning: false, insertIdIsFirstOfBatch: true };
+}
+```
+
+| Feature | Value | Consequence |
+| --- | --- | --- |
+| `events` | `true` | Database scheduled events work. |
+| `insertReturning` | `false` | `InsertQueryBuilder.returning()` **throws `NotSupported`**. Generated keys come from `LAST_INSERT_ID()`. |
+| `insertIdIsFirstOfBatch` | **`true`** | The only driver where it holds. A multi-row insert's keys can be walked forwards from the reported id. |
+
+All four isolation levels are declared.
+
+## The contiguous-key guarantee
+
+This is the most consequential thing about the MySQL driver, and it is a documented InnoDB
+guarantee rather than an assumption.
+
+InnoDB splits inserts into two kinds:
+
+- **Simple inserts** — the row count is known before execution. `INSERT INTO t (...) VALUES
+  (...), (...)` is one, and it is the only shape `InsertQueryBuilder` can produce.
+- **Bulk inserts** — `INSERT ... SELECT`, where the count is not known.
+
+For a *simple* insert, InnoDB reserves one contiguous block of N auto-increment values under a
+short mutex it releases immediately, and `LAST_INSERT_ID()` reports **the first of them**. So the
+k-th row of the statement gets `LAST_INSERT_ID() + k`.
+
+This holds under `innodb_autoinc_lock_mode = 2`, the MySQL 8 default. The "values may not be
+contiguous" caveat in the MySQL manual is about *bulk* inserts and about mixed-mode inserts —
+neither of which the builder produces.
+
+### When the ORM actually uses it
+
+`Model.insert([...])` backfills keys positionally only when **every** guard passes:
+
+1. `insertIdIsFirstOfBatch` is true — MySQL only.
+2. The model has exactly **one** primary key column, with `auto` generation. A composite key has
+   no single counter, and `uuid` / `assigned` keys are already set.
+3. `InsertBehaviour` is `None`. `INSERT IGNORE`, `REPLACE` and `ON DUPLICATE KEY UPDATE` are
+   mixed-mode: rows can be skipped, replaced or updated, so the k-th allocated id stops belonging
+   to the k-th input row. (The array path rejects these outright anyway.)
+4. The reported `LastInsertId` is a finite number greater than zero.
+5. `RowsAffected === rows.length` — the server confirms one row inserted per row sent.
+6. **No** input row carried an explicit key. A batch where some rows supply one is mixed-mode:
+   InnoDB allocates values only for the rows that omitted a key, so index arithmetic would both
+   mis-key the generated rows and overwrite the supplied ones.
+
+If any guard fails, **nothing is assigned** — the ORM does not guess. Re-select, or insert one
+row at a time.
+
+```ts sample
+import { Connection, Model, ModelBase, Primary } from '@spinajs/orm';
+
+@Connection('mysql')
+@Model('articles')
+export class Article extends ModelBase<Article> {
+  @Primary()
+  public Id: number;
+
+  public Title: string;
+}
+
+export async function batch() {
+  const rows = [new Article({ Title: 'One' }), new Article({ Title: 'Two' }), new Article({ Title: 'Three' })];
+
+  await Article.insert(rows);
+
+  // On MySQL each instance now carries its generated key.
+  return rows.map((r) => r.Id);
+}
+```
+
+The unit of work does **not** rely on this. `SubjectExecutor` inserts one statement per row
+deliberately, because a subject's key is needed by the very next subject in the order.
+
+## No `RETURNING`
+
+```ts sample
+import { Connection, Model, ModelBase, Primary, createQuery, InsertQueryBuilder } from '@spinajs/orm';
+
+@Connection('mysql')
+@Model('articles')
+export class Article extends ModelBase<Article> {
+  @Primary()
+  public Id: number;
+
+  public Title: string;
+}
+
+export function willThrow() {
+  const { query } = createQuery(Article, InsertQueryBuilder);
+
+  // NotSupported: driver orm-driver-mysql does not support RETURNING on INSERT
+  return () => query.returning(['Id']);
+}
+```
+
+Throwing is deliberate: silently ignoring the call is how this API was a no-op on MySQL and
+MSSQL for years. Read keys back through `LAST_INSERT_ID()` — which the ORM does for you — or
+re-select.
+
+## `MysqlServerResponseMapper`
+
+Normalizes `mysql2`'s `OkPacket` into `{ RowsAffected, LastInsertId, Returning }`.
+`Returning` is always empty, since the dialect echoes nothing back.
+
+`LastInsertId` reports `0` for a `uuid` or `assigned` key on a **successful** insert — those have
+no identity semantics. Only `RowsAffected` is a meaningful success signal for them, which is why
+`fp.ts`'s `_insert` tests that field rather than the id.
+
+## Type mapping
+
+MySQL is the dialect `@spinajs/orm-sql`'s generic compilers were written against, so the type
+mapping is the generic one with no overrides:
+
+| ORM type | MySQL |
+| --- | --- |
+| `string` | `VARCHAR(n)`, default 255 |
+| `text`, `tinytext`, `mediumtext`, `longtext` | the same names |
+| `int`, `tinyint`, `smallint`, `mediumint`, `bigint` | the same names |
+| `float`, `double`, `decimal` | `TYPE(precision, scale)`, defaults `8, 2` |
+| `boolean` | `BOOLEAN` |
+| `date`, `dateTime`, `time`, `timestamp` | the same names |
+| `enum` | `ENUM('a','b')` |
+| `set` | `SET('a','b')` |
+| `json` | `JSON` |
+| `binary` | `BINARY(n)`, default 255 |
+| `tinyblob`, `mediumblob`, `longblob` | the same names |
+
+Auto-increment is `AUTO_INCREMENT`. Upserts are `ON DUPLICATE KEY UPDATE`. `TRUNCATE TABLE`
+works and **resets** the auto-increment counter.
+
+`@Uuid` columns pair with `table.uuid(name)` — `BINARY(16)` — which is what `UuidConverter`
+writes.
+
+Native `SET` columns are real here, so `@Set()` and `whereInSet` / `whereNotInSet` map onto
+`FIND_IN_SET` against an actual `SET` column rather than an emulation.
+
+## Compiler overrides
+
+Only two, which is a fair measure of how closely the generic layer tracks MySQL:
+
+| Token | Implementation |
+| --- | --- |
+| `TableExistsCompiler` | `MySqlTableExistsCompiler` — queries `information_schema.tables` |
+| `ServerResponseMapper` | `MysqlServerResponseMapper` |
+
+Everything else comes from [`@spinajs/orm-sql`](../../orm-sql/docs/), including multi-column
+`ORDER BY` — unlike SQLite, which reduces it to one column.
+
+## Database events
+
+`events: true`, so the schema builder's event API works.
+
+```ts sample
+import { Migration, OrmMigration, OrmDriver } from '@spinajs/orm';
+
+@Migration('mysql')
+export class ScheduleCleanup_2026_07_27_21_00_00 extends OrmMigration {
+  public async up(connection: OrmDriver): Promise<void> {
+    if (!connection.supportedFeatures().events) {
+      return;
+    }
+
+    const event = connection.schema().event('purge_old_sessions');
+    event.every().hour(1);
+    event.comment('Delete sessions older than a day');
+    event.do(connection.del().from('sessions').where('CreatedAt', '<', '2026-01-01'));
+
+    await event;
+  }
+
+  public async down(connection: OrmDriver): Promise<void> {
+    if (!connection.supportedFeatures().events) {
+      return;
+    }
+
+    await connection.schema().dropEvent('purge_old_sessions');
+  }
+}
+```
+
+The MySQL event scheduler must be running (`SET GLOBAL event_scheduler = ON`), and the user needs
+the `EVENT` privilege. Guard with `supportedFeatures().events` regardless, so the same migration
+is safe on SQLite.
+
+## `tableInfo`
+
+Reflection queries `information_schema`, scoped by `Options.Database`. It populates `Name`,
+`Type`, `NativeType` (the full `int(10) unsigned` form), `MaxLength`, `Unsigned`, `Nullable`,
+`DefaultValue`, `PrimaryKey`, `AutoIncrement`, `Unique` and `Comment`, plus foreign-key details.
+
+A rich `NativeType` matters beyond display: the orphan-policy resolver refuses to act on a column
+whose `NativeType` is empty, treating it as "the database never told us".
+
+## DDL is not transactional
+
+`Migration.Transaction.Mode = PerMigration` opens a transaction, but MySQL commits implicitly
+before each DDL statement. A migration that fails after its third `CREATE TABLE` leaves all three
+applied.
+
+Practical consequences:
+
+- Keep migrations small, so a partial application is easy to reason about.
+- Write `down()` defensively — it may run against a half-applied `up()`.
+- Do not rely on rollback for schema changes. Data changes inside `data()` *are* transactional.
+
+## MariaDB
+
+The driver targets `mysql2`, which speaks MariaDB's protocol, and the two are compatible for
+everything documented here. The one thing worth verifying on MariaDB is the contiguous-key
+guarantee: it derives from InnoDB's `innodb_autoinc_lock_mode` semantics, so confirm that
+variable's value before relying on positional batch key backfill.
+
+## Summary
+
+| Behaviour | MySQL |
+| --- | --- |
+| `RETURNING` | Not supported — throws |
+| Batch key backfill | Supported, under six guards |
+| Events | Supported |
+| Isolation levels | All four |
+| `TRUNCATE` | Real, resets the counter |
+| Multi-column `ORDER BY` | Supported |
+| Native `SET` / `ENUM` | Yes |
+| DDL in a transaction | No — implicit commit |
+| Composite keys with auto-increment | Allowed by the engine, but the ORM's batch backfill declines to key them |

--- a/packages/orm-mysql/docs/README.md
+++ b/packages/orm-mysql/docs/README.md
@@ -1,0 +1,88 @@
+# `@spinajs/orm-mysql` documentation
+
+The MySQL / MariaDB dialect driver, built on [`@spinajs/orm-sql`](../../orm-sql/docs/). Ships two
+drivers: `MySqlOrmDriver` and `MySqlSSHOrmDriver`, which tunnels the connection over SSH.
+
+| | Page | Covers |
+| --- | --- | --- |
+| 01 | [Configuration](01-configuration.md) | Connection options, pooling, SSH tunnelling |
+| 02 | [Dialect notes](02-dialect-notes.md) | Feature support, the contiguous-key guarantee, overrides |
+
+## Quick start
+
+```bash
+npm install @spinajs/orm @spinajs/orm-mysql
+```
+
+```ts sample
+import { DI } from '@spinajs/di';
+import { Orm } from '@spinajs/orm';
+import { MySqlOrmDriver } from '@spinajs/orm-mysql';
+
+export async function bootstrap() {
+  DI.register(MySqlOrmDriver).as('orm-driver-mysql');
+  return await DI.resolve(Orm);
+}
+```
+
+```ts sample
+import { FrameworkConfiguration } from '@spinajs/configuration';
+import _ from 'lodash';
+
+export class AppConfiguration extends FrameworkConfiguration {
+  public async resolve(): Promise<void> {
+    await super.resolve();
+
+    this.Config = _.merge(this.Config, {
+      db: {
+        DefaultConnection: 'mysql',
+        Connections: [
+          {
+            Name: 'mysql',
+            Driver: 'orm-driver-mysql',
+            Host: '127.0.0.1',
+            Port: 3306,
+            User: 'app',
+            Password: 'secret',
+            Database: 'app',
+            Encoding: 'utf8mb4',
+            Pool: { Min: 2, Max: 20 },
+            Migration: { OnStartup: true },
+          },
+        ],
+      },
+    });
+  }
+}
+```
+
+## What is distinctive here
+
+- **`insertIdIsFirstOfBatch: true`** — the only driver where it holds. A multi-row insert's
+  generated keys can be read as `LAST_INSERT_ID() + index`. See
+  [02-dialect-notes.md](02-dialect-notes.md).
+- **No `RETURNING`.** `InsertQueryBuilder.returning()` throws `NotSupported`.
+- **Database events are supported**, unlike SQLite.
+- **All four isolation levels** are honoured.
+- **Retries are suppressed inside a transaction** — the driver overrides `isRetryableError` to
+  say so explicitly.
+
+## Testing
+
+Unit tests need no server:
+
+```bash
+cd packages/orm-mysql && npm test
+```
+
+Integration tests need the container from the repository root:
+
+```bash
+docker compose --profile test up -d mysql
+docker compose ps                      # wait for the healthcheck
+cd packages/orm-mysql && npm run test:integration
+```
+
+The container publishes MySQL on host port **3900**, deliberately not 3306, so it cannot collide
+with a local MySQL. See the [repository README](../../../README.md) for the environment variables
+the suite reads.

--- a/packages/orm-mysql/package.json
+++ b/packages/orm-mysql/package.json
@@ -25,7 +25,7 @@
     "test": "ts-mocha -p tsconfig.json test/*.test.ts",
     "test:integration": "ts-mocha -p tsconfig.json test/integration/**/*.test.ts",
     "coverage": "nyc npm run test",
-    "build-docs": "rimraf docs && typedoc --options typedoc.json src/",
+    "build-docs": "rimraf api-docs && typedoc --options typedoc.json src/",
     "format": "prettier --write \"src/**/*.ts\"",
     "lint": "eslint -c .eslintrc.cjs --ext .ts src --fix",
     "preversion": "npm run lint",

--- a/packages/orm-mysql/typedoc.json
+++ b/packages/orm-mysql/typedoc.json
@@ -1,6 +1,6 @@
 {
     "mode": "modules",
-    "out": "docs",
+    "out": "api-docs",
     "name": "spine",
     "theme": "default",
     "ignoreCompilerErrors": "true",

--- a/packages/orm-sql/.gitignore
+++ b/packages/orm-sql/.gitignore
@@ -61,6 +61,6 @@ jspm_packages/
 tsconfig.tsbuildinfo
 
 # doc
-docs
+api-docs
 
 lib

--- a/packages/orm-sql/README.md
+++ b/packages/orm-sql/README.md
@@ -1,11 +1,69 @@
 # `@spinajs/orm-sql`
 
-> TODO: description
+The generic SQL layer for [`@spinajs/orm`](../orm): concrete, dialect-neutral statements and
+compilers, plus `SqlDriver` — the base class every dialect driver extends.
+
+You rarely install it directly. It arrives as a dependency of
+[`@spinajs/orm-sqlite`](../orm-sqlite), [`@spinajs/orm-mysql`](../orm-mysql) or
+[`@spinajs/orm-mssql`](../orm-mssql).
+
+## What it provides
+
+- **`SqlDriver`** — implements `OrmDriver.execute()` in terms of one abstract method,
+  `executeOnDb(stmt, params, context)`. A dialect driver only has to know how to send a string
+  with bindings to its server.
+- **Statements** — `SqlWhereStatement`, `SqlJoinStatement`, `SqlColumnStatement`,
+  `SqlInStatement`, `SqlExistsQueryStatement` and the rest.
+- **Compilers** — one per query shape, from `SqlSelectQueryCompiler` to
+  `SqlTableHistoryQueryCompiler`.
+- **Converters** — `SqlDatetimeValueConverter`, `SqlBooleanValueConverter`,
+  `SqlTimeValueConverter`, `SqlSetConverter`.
+
+`SqlDriver.resolve()` registers all of it into the driver's own child DI container, so a dialect
+overrides only what genuinely differs.
 
 ## Usage
 
-```
-const ormSql = require('@spinajs/orm-sql');
+```ts
+import { SqlDriver } from '@spinajs/orm-sql';
+import { QueryContext, ServerResponseMapper } from '@spinajs/orm';
+import { Injectable } from '@spinajs/di';
 
-// TODO: DEMONSTRATE API
+@Injectable('orm-driver-mydb')
+export class MyDbOrmDriver extends SqlDriver {
+  public async executeOnDb(stmt: string, params: unknown[], _context: QueryContext) {
+    return this.withReconnect(() => myClient.query(stmt, params));
+  }
+
+  public resolve() {
+    super.resolve();
+    // Mandatory: no generic implementation exists for either of these.
+    this.Container.register(MyServerResponseMapper).as(ServerResponseMapper);
+    this.Container.register(MyTableExistsCompiler).as(TableExistsCompiler);
+  }
+
+  // ... connect / disconnect / ping / supportedFeatures / tableInfo
+  // ... plus the six transaction primitives
+}
+```
+
+## Documentation
+
+Full documentation lives in **[docs/](docs/)**.
+
+| | Page |
+| --- | --- |
+| 01 | [Overview](docs/01-overview.md) |
+| 02 | [Compilers](docs/02-compilers.md) |
+| 03 | [Statements](docs/03-statements.md) |
+| 04 | [Writing a driver](docs/04-writing-a-driver.md) |
+
+See also [the core's architecture page](../orm/docs/12-architecture.md) for how a query becomes
+SQL, end to end.
+
+## Development
+
+```bash
+npm test        # compiles builders and asserts on the SQL — no database required
+npm run build
 ```

--- a/packages/orm-sql/docs/01-overview.md
+++ b/packages/orm-sql/docs/01-overview.md
@@ -1,0 +1,184 @@
+# Overview
+
+## Where this package sits
+
+```
+@spinajs/orm          abstract WhereStatement, SelectQueryCompiler, ...
+      │               resolves them from the connection's DI container
+      ▼
+@spinajs/orm-sql      SqlWhereStatement, SqlSelectQueryCompiler, ...   ← this package
+      │               SqlDriver: execute() + all the registrations
+      ▼
+@spinajs/orm-sqlite   dialect overrides + connection handling
+@spinajs/orm-mysql
+@spinajs/orm-mssql
+```
+
+The core never instantiates a statement or compiler directly. It calls
+`container.resolve(WhereStatement, [...])`, and what comes back is whatever the driver's
+container has bound to that token. `SqlDriver.resolve()` binds the generic SQL implementations;
+a dialect then overrides the handful that differ.
+
+That indirection is why the core can contain no SQL at all, and why two connections on different
+dialects coexist — each driver owns a **child container**.
+
+## `SqlDriver`
+
+An abstract `OrmDriver` that implements `execute()` in terms of one new abstract method.
+
+```ts
+export abstract class SqlDriver extends OrmDriver {
+  public abstract executeOnDb(stmt: string | object, params: any[], context: QueryContext): Promise<any[] | any>;
+}
+```
+
+`execute(builder)` compiles the builder and hands the result to `executeOnDb`:
+
+1. `builder.toDB()` → `ICompilerOutput` or `ICompilerOutput[]`.
+2. An **array** result (multi-statement DDL — `ALTER TABLE`, table clone, events, history
+   tracking) is run through `Promise.all`, one `executeOnDb` per statement.
+3. A single result is run once.
+4. Either way the call is wrapped in `Perf.measure('orm.query', ...)`, labelled with `driver`
+   and `context`, carrying the SQL and bindings as fields.
+5. A throw is logged at `error` with the message, stack, model name and query context, then
+   re-thrown.
+
+A dialect driver therefore only has to know how to send a string with bindings to its server, plus
+connect / disconnect / ping / `tableInfo` / `supportedFeatures` and the six transaction
+primitives.
+
+## What `SqlDriver.resolve()` registers
+
+Everything below lands in the **driver's own child container**, on top of what
+`OrmDriver.resolve()` already registered (`StandardModelToSqlConverter`,
+`StandardObjectToSqlConverter`, `JsonValueConverter`, `UuidConverter`,
+`UniversalValueConverter`).
+
+### Statements
+
+| Token | Implementation |
+| --- | --- |
+| `InStatement` | `SqlInStatement` |
+| `InSetStatement` | `SqlInSetStatement` |
+| `RawQueryStatement` | `SqlRawStatement` |
+| `BetweenStatement` | `SqlBetweenStatement` |
+| `WhereStatement` | `SqlWhereStatement` |
+| `WhereQueryStatement` | `SqlWhereQueryStatement` |
+| `ColumnStatement` | `SqlColumnStatement` |
+| `ColumnRawStatement` | `SqlColumnRawStatement` |
+| `ColumnMethodStatement` | `SqlColumnMethodStatement` |
+| `ExistsQueryStatement` | `SqlExistsQueryStatement` |
+| `JoinStatement` | `SqlJoinStatement` |
+| `WithRecursiveStatement` | `SqlWithRecursiveStatement` |
+| `GroupByStatement` | `SqlGroupByStatement` |
+| `LazyQueryStatement` | `SqlLazyQueryStatement` |
+| `DateWrapper` / `DateTimeWrapper` | `SqlDateWrapper` / `SqlDateTimeWrapper` |
+
+### Compilers
+
+| Token | Implementation |
+| --- | --- |
+| `SelectQueryCompiler` | `SqlSelectQueryCompiler` |
+| `UpdateQueryCompiler` | `SqlUpdateQueryCompiler` |
+| `DeleteQueryCompiler` | `SqlDeleteQueryCompiler` |
+| `InsertQueryCompiler` | `SqlInsertQueryCompiler` |
+| `OnDuplicateQueryCompiler` | `SqlOnDuplicateQueryCompiler` |
+| `RecursiveQueryCompiler` | `SqlWithRecursiveCompiler` |
+| `LimitQueryCompiler` | `SqlLimitQueryCompiler` |
+| `OrderByQueryCompiler` | `SqlOrderByQueryCompiler` |
+| `GroupByQueryCompiler` | `SqlGroupByCompiler` |
+| `IndexQueryCompiler` | `SqlIndexQueryCompiler` |
+| `ForeignKeyQueryCompiler` | `SqlForeignKeyQueryCompiler` |
+| `TableQueryCompiler` | `SqlTableQueryCompiler` |
+| `AlterTableQueryCompiler` | `SqlAlterTableQueryCompiler` |
+| `ColumnQueryCompiler` | `SqlColumnQueryCompiler` |
+| `AlterColumnQueryCompiler` | `SqlAlterColumnQueryCompiler` |
+| `TruncateTableQueryCompiler` | `SqlTruncateTableQueryCompiler` |
+| `TableCloneQueryCompiler` | `SqlTableCloneQueryCompiler` |
+| `TableHistoryQueryCompiler` | `SqlTableHistoryQueryCompiler` |
+| `DropTableCompiler` | `SqlDropTableQueryCompiler` |
+| `DropViewCompiler` | `SqlDropViewQueryCompiler` |
+| `EventQueryCompiler` | `SqlEventQueryCompiler` |
+| `DropEventQueryCompiler` | `SqlDropEventQueryCompiler` |
+| `RawSchemaQueryCompiler` | `SqlRawSchemaQueryCompiler` |
+| `TableAliasCompiler` | `SqlTableAliasCompiler` |
+
+### Converters and builders
+
+| Token | Implementation |
+| --- | --- |
+| `DatetimeValueConverter` | `SqlDatetimeValueConverter` |
+| `TimeValueConverter` | `SqlTimeValueConverter` |
+| `BooleanValueConverter` | `SqlBooleanValueConverter` |
+| `SetValueConverter` | `SqlSetConverter` |
+| `DefaultValueBuilder` | `SqlDefaultValueBuilder` |
+
+Notably **not** registered here: `ServerResponseMapper` and `TableExistsCompiler`. Both are
+inherently dialect-specific and every driver must provide them — see
+[04-writing-a-driver.md](04-writing-a-driver.md).
+
+## Converters in detail
+
+### `SqlBooleanValueConverter`
+
+`toDB`: `value ? 1 : 0`.
+`fromDB`: true for `1`, `true` or `'1'`.
+
+### `SqlSetConverter`
+
+`toDB`: joins an array with commas, passing anything else through.
+`fromDB`: splits a string on commas; a non-string becomes `value ?? [value]`.
+
+### `SqlTimeValueConverter`
+
+Converts a `TimeSpan` (`@spinajs/util`) to and from the SQL `TIME` format. It emits
+`HH:MM:SS`, and deliberately allows hours beyond 24 — MySQL `TIME` ranges from `-838:59:59` to
+`838:59:59`, so a duration is representable, not just a clock reading. A value it cannot parse
+becomes `null` rather than a malformed string.
+
+### `SqlDatetimeValueConverter`
+
+Converts between luxon `DateTime` and the database's datetime representation, honouring
+`IDehydrateOptions.dateTimeFormat` (`'iso'`, `'sql'`, `'unix'`).
+
+It handles numeric date columns — a column whose type is one of `int`, `integer`, `float`,
+`double`, `decimal`, `bigint`, `smallint`, `tinyint`, `mediumint` holding a timestamp — as well
+as textual ones, which is how SQLite stores datetimes.
+
+`toDB(undefined)` and `toDB(null)` both return `null`, **not the epoch**.
+
+## Identifier quoting
+
+Generated SQL quotes identifiers with backticks and wraps generated table aliases in
+`Options.AliasSeparator` (`$` by default):
+
+```sql
+SELECT `$users$`.`Name` FROM `users` as `$users$`
+```
+
+MSSQL cannot use either: `$` starts a pseudo-column there, and backticks are not its quoting
+character. Its driver sets `AliasSeparator` to `#` in its constructor and strips backticks in
+`executeOnDb`.
+
+## Testing without a database
+
+`toDB()` compiles without executing, which is how this package's own test suite works — build a
+builder, compile it, assert on the string and the bindings.
+
+```ts sample
+import { Connection, Model, ModelBase, Primary, ICompilerOutput } from '@spinajs/orm';
+
+@Connection('sqlite')
+@Model('users')
+export class User extends ModelBase<User> {
+  @Primary()
+  public Id: number;
+
+  public Name: string;
+}
+
+export function compiled(): ICompilerOutput {
+  return User.where('Name', 'like', 'A%').take(10).toDB() as ICompilerOutput;
+  // → { expression: "SELECT * FROM `users` ... WHERE `Name` like ? LIMIT ?", bindings: ['A%', 10] }
+}
+```

--- a/packages/orm-sql/docs/02-compilers.md
+++ b/packages/orm-sql/docs/02-compilers.md
@@ -1,0 +1,260 @@
+# Compilers
+
+A compiler turns a builder into `ICompilerOutput` — `{ expression, bindings }` — or an array of
+them for multi-statement DDL. Every one is resolved from the driver's container, so a dialect
+overrides by re-registering the token.
+
+## `SqlQueryCompiler<T>`
+
+The shared base. Holds the builder and the container, and exposes them to subclasses. The
+per-clause compilers (`SqlWhereCompiler`, `SqlColumnsCompiler`, …) are mixed in with
+`typescript-mix`'s `@use`, which is why `SqlSelectQueryCompiler` can call `this.where(...)` and
+`this.columns(...)` directly.
+
+## `SqlSelectQueryCompiler`
+
+The clause order in `compile()` is not cosmetic:
+
+1. **`Relations.forEach(r => r.compile())`** — relations register their joins and middlewares.
+2. **JOIN** — first, because a join (an `EXISTS` statement in particular) can change the table
+   alias.
+3. **WHERE** — second, for the same reason.
+4. Then columns, `FROM`, `LIMIT`, `ORDER BY`, `HAVING`, `GROUP BY`.
+
+A recursive builder short-circuits to `SqlWithRecursiveCompiler` before any of this.
+
+Assembled shape:
+
+```
+SELECT [DISTINCT] <columns|*> FROM <table alias> [joins] [WHERE ...] [GROUP BY ...]
+  [HAVING ...] [ORDER BY ...] [LIMIT ...]
+```
+
+Bindings are concatenated in join → where → group → having → sort → limit order, matching the
+`?` placeholders.
+
+An empty column list compiles to `*`.
+
+## `SqlLimitQueryCompiler`
+
+| Builder state | SQL |
+| --- | --- |
+| `limit > 0` | `LIMIT ?` |
+| `limit <= 0`, `offset > 0` | `LIMIT 18446744073709551615` |
+| `offset > 0` | `OFFSET ?` appended |
+
+The magic number is `2^64 - 1`: standard SQL has no `OFFSET` without a `LIMIT`, so an
+effectively-unbounded limit stands in. Dialects that support a bare `OFFSET` override this
+compiler. It throws `builder cannot be null or undefined` on a missing builder.
+
+## `SqlWhereCompiler`
+
+Builds each statement and joins them with their own boolean connector.
+
+One ordering rule matters: **lazy statements are built first**, and their results reused.
+`LazyQueryStatement.build()` may have side effects that append further statements to the builder
+— a correlated `EXISTS` sub-query registers its correlation predicate lazily — so building them
+up front guarantees the side effect runs exactly once and that the appended statements are
+picked up by the same pass.
+
+`SqlHavingCompiler` is the same logic emitting a `HAVING` clause.
+
+## `SqlColumnsCompiler`
+
+Maps each column statement's first built fragment and joins with commas.
+
+## `SqlGroupByCompiler`
+
+`GROUP BY` plus the joined statements; an empty expression when there are none.
+
+## `SqlOrderByQueryCompiler`
+
+Emits `ORDER BY` over **every** entry from `getSorts()`, so multi-column ordering works.
+Empty when there are no sorts.
+
+## `SqlJoinCompiler`
+
+Concatenates the built join statements.
+
+## `SqlWithRecursiveCompiler`
+
+Compiles the `WITH RECURSIVE` CTE. It builds two **clones** of the owning query — the anchor
+member and the recursive member — with `clearRecursive()` applied, so compiling a member cannot
+re-enter the recursive compiler and loop forever. `clearJoins()` and `clearWhere()` strip the
+parts of the parent query the members must not inherit.
+
+## `SqlInsertQueryCompiler`
+
+```
+INSERT INTO <table> (<columns>) VALUES (?, ?), (?, ?) [upsert clause]
+```
+
+The subtle part is `keptColumnIndices()`. An auto-increment primary key column is dropped from
+the statement **only when no row supplies a value for it**. If at least one row does, the column
+stays and the rows that omitted it emit `NULL`, letting the engine assign those.
+
+Both `columns()` and `values()` derive their shape from that single decision. Deciding per-row
+in one place and per-batch in the other produced value tuples whose arity did not match the
+column list.
+
+An empty `Values` array throws `values count invalid`.
+
+`orIgnore()` and `orReplace()` change the verb; `onDuplicate()` appends the upsert clause via
+`SqlOnDuplicateQueryCompiler`. `Replace` wins over `Update` — the upsert clause is skipped when
+both are set.
+
+## `SqlOnDuplicateQueryCompiler`
+
+Emits the dialect's upsert tail from the `OnDuplicateQueryBuilder`'s conflict columns and update
+list. MySQL's `ON DUPLICATE KEY UPDATE` and SQLite's `ON CONFLICT (...) DO UPDATE SET` differ
+enough that SQLite overrides it.
+
+## `SqlUpdateQueryCompiler`
+
+```
+UPDATE <table alias> SET `col` = ?, ... [WHERE ...]
+```
+
+Bindings are the `SET` values followed by the where bindings.
+
+## `SqlDeleteQueryCompiler`
+
+```
+DELETE FROM <table alias> [WHERE ...] [LIMIT ...]
+```
+
+## `SqlTableQueryCompiler`
+
+`CREATE TABLE`, delegating each column to `SqlColumnQueryCompiler` and each foreign key to
+`SqlForeignKeyQueryCompiler`. Handles `temporary()`, `ifExists()`, the table comment and charset.
+
+`trackHistory()` makes `compile()` return an **array**: the table statement plus everything
+`SqlTableHistoryQueryCompiler` emits.
+
+## `SqlColumnQueryCompiler`
+
+Maps a `ColumnType` to its SQL type.
+
+| Builder type | SQL |
+| --- | --- |
+| `string` | `VARCHAR(n)`, default `255` |
+| `float` / `double` / `decimal` | `TYPE(precision, scale)`, defaults `8, 2` |
+| `enum` | `ENUM('a','b')` |
+| `set` | `SET('a','b')` |
+| `binary` | `BINARY(n)`, default `255` |
+| `boolean` | `BOOLEAN` |
+| everything else | the type name, uppercased |
+
+Then the modifiers, in order: `UNSIGNED`, `CHARACTER SET '...'`, `COLLATE '...'`, `NOT NULL`,
+`DEFAULT ...`, `AUTO_INCREMENT`, `COMMENT '...'`, and an inline `PRIMARY KEY` when
+`InlinePrimaryKey` is set.
+
+Identifiers go through `escapeIdentifier`, and every string literal — enum and set members,
+charset, collation, comment — through `escapeStringLiteral`.
+
+`AUTO_INCREMENT` is MySQL's spelling. SQLite (`AUTOINCREMENT`) and MSSQL (`IDENTITY(1,1)`)
+override it.
+
+## `SqlAlterTableQueryCompiler`
+
+Returns an **array** — one statement per alteration, which is what most dialects require.
+Handles adds, modifies, renames, dropped columns and a table rename, delegating columns to
+`SqlAlterColumnQueryCompiler`.
+
+## `SqlForeignKeyQueryCompiler`
+
+```
+FOREIGN KEY (`col`) REFERENCES `table`(`pk`) ON DELETE <action> ON UPDATE <action>
+```
+
+Actions come from `ReferentialAction`, defaulting to `NO ACTION`.
+
+## `SqlIndexQueryCompiler`
+
+```
+CREATE [UNIQUE] INDEX `name` ON `table` (`col`, ...)
+```
+
+## `SqlTruncateTableQueryCompiler`
+
+`TRUNCATE TABLE <table>`. SQLite has no such statement and overrides it with a `DELETE`.
+
+## `SqlTableCloneQueryCompiler`
+
+Returns an array. A shallow clone emits the structure copy; a deep clone adds an
+`INSERT ... SELECT`, constrained by the filter builder when one was given.
+
+## `SqlTableHistoryQueryCompiler`
+
+Emits the history table and the triggers that populate it, giving each row `__action__`,
+`__revision__`, `__start__` and `__end__` — the `IHistoricalModel` shape read back through
+`@Historical`.
+
+## `SqlDropTableQueryCompiler` / `SqlDropViewQueryCompiler`
+
+`DROP TABLE|VIEW [IF EXISTS] <name>`, schema-qualified when `database()` was set.
+
+## `SqlEventQueryCompiler` / `SqlDropEventQueryCompiler`
+
+Database scheduled events, from `EventQueryBuilder`. Both return arrays. Only meaningful where
+`supportedFeatures().events` is true.
+
+## `SqlRawSchemaQueryCompiler`
+
+Passes a `RawSchemaQueryBuilder`'s query and bindings straight through.
+
+## `SqlTableAliasCompiler`
+
+A `@Singleton` that renders a table reference:
+
+```sql
+`database`.`table` as `$table$`
+```
+
+The alias wrapper is `Options.AliasSeparator`. The database prefix appears only when the builder
+has one.
+
+## Not provided here
+
+`TableExistsCompiler` has no generic implementation — every dialect answers the question
+differently (`information_schema`, `sqlite_master`, `sys.tables`). Each driver registers its own.
+
+## Overriding one
+
+```ts sample
+import { SqlDriver } from '@spinajs/orm-sql';
+import { SqlLimitQueryCompiler } from '@spinajs/orm-sql';
+import { LimitQueryCompiler, ICompilerOutput, ILimitBuilder, QueryContext } from '@spinajs/orm';
+
+/** A dialect that supports a bare OFFSET, so the 2^64-1 stand-in is unnecessary. */
+export class PostgresLimitCompiler extends SqlLimitQueryCompiler {
+  public compile(): ICompilerOutput {
+    const limits = (this as unknown as { _builder: ILimitBuilder<unknown> })._builder.getLimits();
+    const bindings: unknown[] = [];
+    let stmt = '';
+
+    if ((limits.limit ?? 0) > 0) {
+      stmt += ' LIMIT ?';
+      bindings.push(limits.limit);
+    }
+
+    if ((limits.offset ?? 0) > 0) {
+      stmt += ' OFFSET ?';
+      bindings.push(limits.offset);
+    }
+
+    return { bindings, expression: stmt };
+  }
+}
+
+export abstract class PostgresDriver extends SqlDriver {
+  public abstract executeOnDb(stmt: string | object, params: unknown[], context: QueryContext): Promise<unknown>;
+
+  public resolve() {
+    super.resolve();
+    this.Container.register(PostgresLimitCompiler).as(LimitQueryCompiler);
+  }
+}
+```
+
+Register **after** `super.resolve()`, so your binding replaces the generic one.

--- a/packages/orm-sql/docs/03-statements.md
+++ b/packages/orm-sql/docs/03-statements.md
@@ -1,0 +1,210 @@
+# Statements
+
+A statement is one compilable fragment: a `WHERE` predicate, a selected column, a join, a group
+key. Each implements two methods.
+
+```ts
+interface IQueryStatement {
+  build(): IQueryStatementResult;                       // { Statements: string[], Bindings: any[] }
+  clone(builder?: QueryBuilder): IQueryStatement;
+  Boolean: WhereBoolean;                                // AND / OR connector
+  TableAlias: string;
+}
+```
+
+`clone()` rebuilds the statement from its parts against a new builder. `WhereBuilder.clone()`
+copies `Boolean` back onto the clone afterwards, because a rebuilt statement would otherwise
+reset it to the `AND` default.
+
+## `SqlWhereStatement`
+
+The workhorse. `build()` does five things:
+
+1. **Relation name → foreign key.** When the column names a relation on the model, it is swapped
+   for the relation's `ForeignKey`.
+2. **`Wrap` columns** are handed to their `WrapStatement` (`SqlDateWrapper`,
+   `SqlDateTimeWrapper`) and the result used as the column expression. Otherwise the column is
+   escaped and prefixed with the table alias.
+3. **A `ModelBase` value unwraps to its primary key.** A **composite** key throws rather than
+   binding a tuple into a single `?`:
+
+   ```
+   cannot use model X as a where value: it has a composite primary key (A, B).
+   Compare the key columns explicitly.
+   ```
+4. **Converter lookup.** A converter declared on the column wins. Failing that, the value's own
+   constructor name is looked up in `__orm_db_value_converters__` — which is how a luxon
+   `DateTime` passed as a where value is converted without any per-column declaration.
+5. **Null operators bind nothing.** `IS NULL` and `IS NOT NULL` emit no `?` and no binding.
+
+Output: `` `alias`.`column` <OPERATOR> ? ``, with the operator uppercased.
+
+## `SqlInStatement`
+
+```sql
+`alias`.`column` IN (?, ?, ?)
+```
+
+`NOT IN` when negated. Bindings are the values.
+
+Note that the empty-array case never reaches here — `WhereBuilder.whereIn` short-circuits to
+`FALSE` before constructing a statement.
+
+## `SqlInSetStatement`
+
+Membership in a MySQL `SET` column, via `FIND_IN_SET`.
+
+| Mode | SQL | Connector |
+| --- | --- | --- |
+| `whereInSet` | `FIND_IN_SET(?, col) > 0` | `OR` |
+| `whereNotInSet` | `FIND_IN_SET(?, col) = 0` | `AND` |
+
+Wrapped in parentheses. The connector flip is deliberate: "in any of these" is a disjunction,
+"in none of these" is a conjunction.
+
+## `SqlBetweenStatement`
+
+```sql
+`alias`.`column` BETWEEN ? AND ?
+```
+
+`NOT BETWEEN` when negated.
+
+## `SqlColumnStatement`
+
+An escaped column with an optional alias, prefixed with the table alias:
+
+```sql
+`$users$`.`Name` as `DisplayName`
+```
+
+A wildcard column compiles to `*` (still alias-prefixed when there is an alias).
+
+Column existence is validated in the **core** `ColumnStatement` constructor, not here.
+Properties present on the prototype without a decorator, and primary keys declared only via
+`@Primary`, are allowed; anything else throws `column X not exists in model Y`.
+
+## `SqlColumnRawStatement`
+
+A `RawQuery` used as a selected column, passed through with its bindings.
+
+## `SqlColumnMethodStatement`
+
+An aggregate: `MIN`, `MAX`, `SUM`, `AVG`, `COUNT` from `ColumnMethods`.
+
+```sql
+COUNT(`$orders$`.`Id`) as `count`
+```
+
+## `SqlRawStatement`
+
+A `RawQuery` in a `WHERE`, emitted verbatim with its bindings.
+
+## `SqlWhereQueryStatement`
+
+A nested group — what `where(function () { ... })` produces. Compiles its child builder and wraps
+the result in parentheses, so the group's own boolean connectors stay contained.
+
+## `SqlExistsQueryStatement`
+
+```sql
+EXISTS ( <subquery> )
+```
+
+`NOT EXISTS` when negated. The sub-query is compiled with its own bindings.
+
+## `SqlLazyQueryStatement`
+
+Defers building until compile time, so the statement can depend on state that does not exist at
+`where()` time.
+
+`SqlWhereCompiler` builds these **first** and reuses the result. Building a lazy statement may
+append further statements to the builder — a correlated `EXISTS` registers its correlation
+predicate lazily — and building up front guarantees the side effect runs exactly once, in a pass
+that still sees what it appended.
+
+## `SqlJoinStatement`
+
+Emits the join. `JoinMethod.RECURSIVE` is compiled as `INNER JOIN`; anything unspecified
+defaults to `LEFT JOIN`.
+
+Three input shapes:
+
+- **A raw query** — emitted verbatim.
+- **A relation or model** — the ON clause is derived from the relation descriptor.
+- **Explicit options** — `sourceTablePrimaryKey`, `joinTableForeignKey` and the table names.
+
+When the join carries a `callback`, the statement builds a **sub-builder** on the joined model
+and applies the callback to it. That sub-builder's `WHERE` conditions are emitted in the join's
+own **ON** clause and deliberately **not** folded into the main query's `WHERE` — folding them
+would silently turn a `LEFT JOIN` into an inner filter. Columns and sorts from a
+`queryCallback` *are* merged, so extra joined columns keep working.
+
+## `SqlGroupByStatement`
+
+A group key: an escaped column, or a raw expression passed through.
+
+## `SqlWithRecursiveStatement`
+
+Builds the `WITH RECURSIVE` CTE by compiling two clones of the owning query — the anchor member
+and the recursive member — each with `clearRecursive()`, `clearJoins()` and `clearWhere()`
+applied as appropriate. Without clearing the recursive flag, compiling a member would re-enter
+the recursive compiler and recurse until the stack overflowed.
+
+## `SqlDateWrapper` / `SqlDateTimeWrapper`
+
+Both **abstract** here — date truncation syntax is genuinely dialect-specific (`DATE()`,
+`CAST(... AS DATE)`, `CONVERT(date, ...)`), so each driver implements them.
+
+Use them through `Wrap`:
+
+```ts sample
+import { Connection, Model, ModelBase, Primary, Wrap, DateWrapper, ICompilerOutput } from '@spinajs/orm';
+
+@Connection('sqlite')
+@Model('orders')
+export class Order extends ModelBase<Order> {
+  @Primary()
+  public Id: number;
+
+  public CreatedAt: string;
+}
+
+export function byDay(): ICompilerOutput {
+  // Compare the DATE part of a datetime column, whatever the dialect spells it as.
+  return Order.where(new Wrap('CreatedAt', DateWrapper), '=', '2026-07-27').toDB() as ICompilerOutput;
+}
+```
+
+## Escaping helpers
+
+| Helper | Purpose |
+| --- | --- |
+| `escapeIdentifier(name)` | Quote a table / column / alias. |
+| `escapeStringLiteral(value)` | Escape a literal embedded in DDL — enum and set members, charset, collation, comments. |
+| `_columnWrap(column, tableAlias, isAggregate?)` | Escape and alias-prefix a column, skipping the prefix for an aggregate expression. |
+
+Values in DML are **always** bound, never interpolated. String literals are escaped only in DDL,
+where the dialects do not accept placeholders.
+
+## Overriding a statement
+
+```ts sample
+import { SqlDriver, SqlDateWrapper } from '@spinajs/orm-sql';
+import { DateWrapper, QueryContext } from '@spinajs/orm';
+
+export class MyDateWrapper extends SqlDateWrapper {
+  public wrap(): string {
+    return `CAST(${this._value} AS DATE)`;
+  }
+}
+
+export abstract class MyDriver extends SqlDriver {
+  public abstract executeOnDb(stmt: string | object, params: unknown[], context: QueryContext): Promise<unknown>;
+
+  public resolve() {
+    super.resolve();
+    this.Container.register(MyDateWrapper).as(DateWrapper);
+  }
+}
+```

--- a/packages/orm-sql/docs/04-writing-a-driver.md
+++ b/packages/orm-sql/docs/04-writing-a-driver.md
@@ -1,0 +1,239 @@
+# Writing a dialect driver
+
+What it takes to add a new database to the ORM, using the three shipped drivers as the reference.
+
+## The contract
+
+Extend `SqlDriver` and implement:
+
+| Member | Purpose |
+| --- | --- |
+| `executeOnDb(stmt, params, context)` | Send one compiled statement to the server. |
+| `connect()` / `disconnect()` | Open and close the connection or pool. |
+| `ping()` | Cheap liveness probe for the health check. |
+| `supportedFeatures()` | Declare `events`, `insertReturning`, `insertIdIsFirstOfBatch`. |
+| `tableInfo(name, schema?)` | Reflect a table into `IColumnDescriptor[]`. |
+| `_begin` `_commit` `_rollback` `_savepoint` `_releaseSavepoint` `_rollbackToSavepoint` `_dispose` | Transaction primitives. |
+| `resolve()` | Register your dialect's overrides. |
+
+Two registrations are **mandatory** and have no generic implementation:
+
+- `ServerResponseMapper` — normalizes your insert response into
+  `{ RowsAffected, LastInsertId, Returning }`. The base class throws with a message naming the
+  contract, rather than dying with `read is not a function` deep inside a middleware.
+- `TableExistsCompiler` — every dialect answers "does this table exist" differently.
+
+## Skeleton
+
+```ts sample
+import { Injectable, NewInstance } from '@spinajs/di';
+import { SqlDriver } from '@spinajs/orm-sql';
+import {
+  IColumnDescriptor,
+  ISupportedFeature,
+  IsolationLevel,
+  ITransactionContext,
+  ITransactionOptions,
+  QueryContext,
+  ServerResponseMapper,
+  OrmDriver,
+  IPoolMetrics,
+} from '@spinajs/orm';
+
+export class MyServerResponseMapper extends ServerResponseMapper {
+  public read(data: any, _pkNames?: string[]) {
+    return {
+      RowsAffected: data?.affectedRows ?? 0,
+      LastInsertId: data?.insertId ?? 0,
+      Returning: [] as any[],
+    };
+  }
+}
+
+@Injectable('orm-driver-mydb')
+@NewInstance()
+export class MyDbOrmDriver extends SqlDriver {
+  public readonly SupportedIsolationLevels: IsolationLevel[] = ['READ COMMITTED', 'SERIALIZABLE'];
+
+  public async executeOnDb(stmt: string | object, params: unknown[], _context: QueryContext): Promise<unknown> {
+    // Reads and writes both go through withReconnect: it only re-runs on transport
+    // failures, where the statement provably never reached the server.
+    return this.withReconnect(async () => {
+      void stmt;
+      void params;
+      return [];
+    });
+  }
+
+  public async connect(): Promise<OrmDriver> {
+    return this;
+  }
+
+  public async disconnect(): Promise<OrmDriver> {
+    return this;
+  }
+
+  public async ping(): Promise<boolean> {
+    return true;
+  }
+
+  public supportedFeatures(): ISupportedFeature {
+    return { events: false, insertReturning: true, insertIdIsFirstOfBatch: false };
+  }
+
+  public async tableInfo(_name: string, _schema?: string): Promise<IColumnDescriptor[]> {
+    return [];
+  }
+
+  public poolMetrics(): IPoolMetrics {
+    return { Size: 1, InUse: 0, Waiting: 0 };
+  }
+
+  public resolve() {
+    super.resolve();
+    this.Container.register(MyServerResponseMapper).as(ServerResponseMapper);
+    // ... plus TableExistsCompiler and any dialect overrides
+  }
+
+  protected async _begin(_options?: ITransactionOptions): Promise<ITransactionContext> {
+    return { depth: 0 };
+  }
+
+  protected async _commit(_ctx: ITransactionContext): Promise<void> {}
+
+  protected async _rollback(_ctx: ITransactionContext): Promise<void> {}
+
+  protected async _savepoint(_ctx: ITransactionContext, _name: string): Promise<void> {}
+
+  protected async _releaseSavepoint(_ctx: ITransactionContext, _name: string): Promise<void> {}
+
+  protected async _rollbackToSavepoint(_ctx: ITransactionContext, _name: string): Promise<void> {}
+
+  protected async _dispose(_ctx: ITransactionContext): Promise<void> {}
+}
+```
+
+Registering under `@Injectable('orm-driver-mydb')` is what lets a connection say
+`Driver: 'orm-driver-mydb'`.
+
+## Declaring features honestly
+
+`ISupportedFeature` drives real behaviour, so a wrong answer produces wrong keys.
+
+### `insertReturning`
+
+Whether a plain `INSERT` can echo rows back. When true, the ORM asks for the primary key
+columns and assigns them authoritatively. When false, `InsertQueryBuilder.returning()` throws
+`NotSupported` rather than silently doing nothing.
+
+### `insertIdIsFirstOfBatch`
+
+Whether the identity value reported after a multi-row `INSERT ... VALUES` names the **first**
+row, with the rest following contiguously.
+
+| Driver | Value | Why |
+| --- | --- | --- |
+| MySQL | `true` | InnoDB treats a statement whose row count is known before execution — every `INSERT ... VALUES (…), (…)` the builder can produce — as a *simple insert*, reserves one contiguous block of auto-increment values under a short mutex, and `LAST_INSERT_ID()` reports the first. Holds under `innodb_autoinc_lock_mode = 2`, the MySQL 8 default. The manual's "values may not be contiguous" caveat is about *bulk* inserts (`INSERT … SELECT`) and mixed-mode inserts. |
+| MSSQL | `false` | `SCOPE_IDENTITY()` returns the **last** identity generated in the scope. |
+| SQLite | `false` | `sqlite3_last_insert_rowid()` is likewise the last row. SQLite gets its keys from `RETURNING` instead. |
+
+The field is optional and defaults to `false`, so a driver that does not set it opts out of the
+batch backfill rather than getting wrong keys.
+
+### `events`
+
+Whether the engine supports scheduled events. MySQL and MSSQL: true. SQLite: false.
+
+## Isolation levels
+
+`SupportedIsolationLevels` is empty by default, meaning **every** explicitly requested level is
+rejected. Declare what you actually honour.
+
+SQLite declares `['SERIALIZABLE']` only — sqlite3 outside shared-cache mode serializes file
+access, which is SERIALIZABLE and nothing else. Requesting anything else is rejected rather than
+quietly ignored.
+
+## Transactions
+
+`OrmDriver.transaction()` orchestrates; your primitives do the work.
+
+- **Pooled driver**: `_begin` acquires a connection and puts it on `ctx.connection`; `_dispose`
+  releases it. MySQL and MSSQL work this way.
+- **Single-handle driver**: `_begin` returns a context with no connection; `_dispose` is a no-op.
+  SQLite works this way.
+
+`ctx.depth` is managed by the base class and used to mint savepoint names (`sp_1`, `sp_2`, …).
+
+Nesting is handled for you: a `transaction()` call inside another takes a savepoint rather than
+opening a second transaction.
+
+## Retries
+
+`withReconnect` retries only transport failures. Extend the retryable set by overriding
+`isRetryableError`.
+
+**Refuse to retry inside a transaction.** The connection carried uncommitted state, and
+replaying one statement after reconnecting would apply it outside the transaction. MySQL's
+driver does exactly this:
+
+```ts
+protected isRetryableError(err: unknown): boolean {
+  if (this.TransactionStorage.getStore()) {
+    return false;
+  }
+  return super.isRetryableError(err);
+}
+```
+
+## Reflecting a schema
+
+`tableInfo` is what turns undecorated model properties into real columns. Fill in as much of
+`IColumnDescriptor` as the dialect exposes: `Name`, `Type`, `NativeType`, `MaxLength`,
+`Nullable`, `DefaultValue`, `PrimaryKey`, `AutoIncrement`, `Unique`, `Unsigned`, `Comment`, and
+`IsForeignKey` / `ForeignKeyDescription` where you can.
+
+`NativeType` matters beyond display: the orphan-policy resolver refuses to act on a column whose
+`NativeType` is empty, treating it as "the database never told us". Populate it.
+
+SQLite reads `PRAGMA table_info`, `PRAGMA index_list` and `PRAGMA foreign_key_list`; MySQL and
+MSSQL query `information_schema`.
+
+## Common overrides
+
+The three shipped drivers between them override roughly this set:
+
+| Concern | Typical override |
+| --- | --- |
+| Identifier quoting | `TableAliasCompiler`, or string surgery in `executeOnDb` (MSSQL strips backticks) |
+| Auto-increment keyword | `ColumnQueryCompiler` — `AUTO_INCREMENT` / `AUTOINCREMENT` / `IDENTITY(1,1)` |
+| Upsert syntax | `OnDuplicateQueryCompiler` — `ON DUPLICATE KEY UPDATE` vs `ON CONFLICT ... DO UPDATE SET` |
+| `INSERT` shape | `InsertQueryCompiler` — `RETURNING` / `OUTPUT` |
+| Truncation | `TruncateTableQueryCompiler` — SQLite has no `TRUNCATE` |
+| Table existence | `TableExistsCompiler` — always |
+| Composite primary keys | `TableQueryCompiler` — SQLite needs a table-level constraint |
+| `ALTER COLUMN` | `AlterColumnQueryCompiler` — SQLite's support is very limited |
+| Date wrapping | `DateWrapper` / `DateTimeWrapper` — abstract in orm-sql |
+| Joins | `JoinStatement` — SQLite lacks `RIGHT JOIN` on older engines |
+| `ORDER BY` | `OrderByQueryCompiler` — collation and null ordering differ |
+| Insert response | `ServerResponseMapper` — always |
+
+Register **after** `super.resolve()`, so your binding replaces the generic one.
+
+## Pool metrics
+
+Override `poolMetrics()` if you own a real pool, and call `observeAcquireSeconds(seconds)` from
+your acquire path. Both must never throw — they run on the health-check timer. Keeping the
+prom-client objects behind those two methods is what stops every driver from needing to know
+about `@spinajs/telemetry-common`.
+
+## Testing
+
+The three shipped drivers all split their suites:
+
+- **Unit tests** compile builders with `toDB()` and assert on the SQL string and bindings. No
+  server needed; they run everywhere.
+- **Integration tests** under `test/integration/` need a live server and run from a separate
+  `npm run test:integration` script, so `npm test` stays green in CI without Docker.
+
+See the repository root [README](../../../README.md) for how the MySQL and MSSQL containers are
+started.

--- a/packages/orm-sql/docs/README.md
+++ b/packages/orm-sql/docs/README.md
@@ -1,0 +1,24 @@
+# `@spinajs/orm-sql` documentation
+
+The generic SQL layer. `@spinajs/orm` deliberately contains no SQL — it declares statement and
+compiler classes as **abstract** and resolves them from the connection's DI container. This
+package provides the concrete, dialect-neutral implementations, plus `SqlDriver`, the base class
+every dialect driver extends.
+
+You rarely install it directly; it arrives as a dependency of `@spinajs/orm-sqlite`,
+`@spinajs/orm-mysql` or `@spinajs/orm-mssql`.
+
+## Pages
+
+| | Page | Covers |
+| --- | --- | --- |
+| 01 | [Overview](01-overview.md) | Where this package sits, `SqlDriver`, what it registers |
+| 02 | [Compilers](02-compilers.md) | Every compiler and the SQL it emits |
+| 03 | [Statements](03-statements.md) | Every statement class and its build rules |
+| 04 | [Writing a driver](04-writing-a-driver.md) | Building a new dialect on top of `SqlDriver` |
+
+## Related
+
+- [`@spinajs/orm`](../../orm/docs/) — the core; start there
+- [`@spinajs/orm/docs/12-architecture.md`](../../orm/docs/12-architecture.md) — how a query
+  becomes SQL, end to end

--- a/packages/orm-sql/package.json
+++ b/packages/orm-sql/package.json
@@ -24,7 +24,7 @@
     "clean": "rimraf lib/ && rimraf tsconfig.tsbuildinfo",
     "test": "ts-mocha -p tsconfig.json test/**/*.test.ts",
     "coverage": "nyc npm run test",
-    "build-docs": "rimraf docs && typedoc --options typedoc.json src/",
+    "build-docs": "rimraf api-docs && typedoc --options typedoc.json src/",
     "format": "prettier --write \"src/**/*.ts\"",
     "lint": "eslint -c .eslintrc.cjs --ext .ts src --fix",
     "preversion": "npm run lint",

--- a/packages/orm-sql/typedoc.json
+++ b/packages/orm-sql/typedoc.json
@@ -1,6 +1,6 @@
 {
     "mode": "modules",
-    "out": "docs",
+    "out": "api-docs",
     "name": "spine",
     "theme": "default",
     "ignoreCompilerErrors": "true",

--- a/packages/orm-sqlite/.gitignore
+++ b/packages/orm-sqlite/.gitignore
@@ -61,6 +61,6 @@ jspm_packages/
 tsconfig.tsbuildinfo
 
 # doc
-docs
+api-docs
 
 lib

--- a/packages/orm-sqlite/README.md
+++ b/packages/orm-sqlite/README.md
@@ -1,11 +1,71 @@
 # `@spinajs/orm-sqlite`
 
-> TODO: description
+The SQLite dialect driver for [`@spinajs/orm`](../orm), built on
+[`@spinajs/orm-sql`](../orm-sql).
+
+## Install
+
+```bash
+npm install @spinajs/orm @spinajs/orm-sqlite
+```
 
 ## Usage
 
-```
-const ormSqlite = require('@spinajs/orm-sqlite');
+```ts
+import { DI } from '@spinajs/di';
+import { Orm } from '@spinajs/orm';
+import { SqliteOrmDriver } from '@spinajs/orm-sqlite';
 
-// TODO: DEMONSTRATE API
+DI.register(SqliteOrmDriver).as('orm-driver-sqlite');
+await DI.resolve(Orm);
+```
+
+```ts
+// configuration
+{
+  db: {
+    DefaultConnection: 'sqlite',
+    Connections: [
+      {
+        Name: 'sqlite',
+        Driver: 'orm-driver-sqlite',
+        Filename: './data/app.sqlite',   // or ':memory:'
+        Pool: { Max: 4 },                // sizes the READ-ONLY handle pool
+        Migration: { OnStartup: true },
+      },
+    ],
+  },
+}
+```
+
+## What is distinctive
+
+- **`Pool.Max` sizes read-only handles, not writers.** SQLite serializes writers at the file
+  level, so extra writer handles buy nothing and invite `SQLITE_BUSY`. The driver opens
+  `Max - 1` read handles instead, skipped entirely for `:memory:` and anonymous temporary
+  databases.
+- **The only driver with `RETURNING`** (`insertReturning: true`), so generated keys come back
+  exactly — including from multi-row inserts.
+- **`SERIALIZABLE` is the only isolation level**, because sqlite3 outside shared-cache mode
+  serializes file access and that *is* SERIALIZABLE.
+- **No database events**, **no `TRUNCATE`** (a `DELETE` stands in, and the auto-increment counter
+  is not reset), and **multi-column `ORDER BY` is reduced to one column**.
+- **No auto-increment column inside a composite primary key** — the compiler throws rather than
+  emit invalid SQL.
+
+## Documentation
+
+Full documentation lives in **[docs/](docs/)**.
+
+| | Page |
+| --- | --- |
+| 01 | [Configuration](docs/01-configuration.md) |
+| 02 | [Dialect notes](docs/02-dialect-notes.md) |
+
+## Development
+
+```bash
+npm test                  # unit suite, no server needed
+npm run test:integration  # creates and removes a temporary on-disk database
+npm run build
 ```

--- a/packages/orm-sqlite/docs/01-configuration.md
+++ b/packages/orm-sqlite/docs/01-configuration.md
@@ -1,0 +1,222 @@
+# Configuration
+
+## Options
+
+Only a subset of `IDriverOptions` is meaningful for a file-backed database.
+
+| Option | Meaning |
+| --- | --- |
+| `Name` | Connection name — what `@Connection('...')` refers to. |
+| `Driver` | `orm-driver-sqlite`, matching the DI registration. |
+| `Filename` | Database file path, `:memory:`, or `''`. **Required.** |
+| `Pool.Max` | Size of the **read-only** handle pool. See below. |
+| `Resilience.*` | Health-check interval and retry policy. |
+| `Migration.*` | `OnStartup`, `Table`, `Transaction.Mode`. |
+| `AliasSeparator` | Defaults to `$`, which SQLite accepts. |
+
+`Host`, `Port`, `User`, `Password`, `Database` and `Encoding` are ignored.
+
+`Filename` is passed through `format({}, ...)` from `@spinajs/configuration`, so it may contain
+configuration placeholders.
+
+```ts sample
+import { FrameworkConfiguration } from '@spinajs/configuration';
+import { MigrationTransactionMode } from '@spinajs/orm';
+import _ from 'lodash';
+
+export class AppConfiguration extends FrameworkConfiguration {
+  public async resolve(): Promise<void> {
+    await super.resolve();
+
+    this.Config = _.merge(this.Config, {
+      db: {
+        DefaultConnection: 'sqlite',
+        Connections: [
+          {
+            Name: 'sqlite',
+            Driver: 'orm-driver-sqlite',
+            Filename: './data/app.sqlite',
+            Pool: { Max: 4 },
+            Resilience: { HealthCheckInterval: 30000 },
+            Migration: {
+              OnStartup: true,
+              Transaction: { Mode: MigrationTransactionMode.PerMigration },
+            },
+          },
+        ],
+      },
+    });
+  }
+}
+```
+
+## The read pool
+
+`Pool.Max` does **not** size a pool of writer connections. SQLite serializes writers at the file
+level no matter how many handles are open, so a second writer handle buys nothing and invites
+`SQLITE_BUSY`. Instead the driver opens `Pool.Max - 1` **read-only** handles, so concurrent
+`SELECT`s stop queueing behind each other.
+
+`handleFor(queryContext)` picks a handle:
+
+- Anything that is **not** a `Select` — mutations, schema changes — stays on the single writer.
+- Anything inside a **transaction** stays on the writer. Scattering a transaction's statements
+  across handles would run them outside the transaction, and a read handle cannot see uncommitted
+  writes.
+- Everything else round-robins across the read pool.
+
+The pool is skipped entirely when:
+
+- `Pool.Max <= 1`;
+- `Filename` is `:memory:`;
+- `Filename` is `''` (an anonymous temporary database).
+
+In those last two cases each handle would open its **own private database**, so a read pool would
+query empty files.
+
+A read handle that fails to open is logged at `warn` and dropped — the driver stays fully usable
+on the writer alone.
+
+`poolMetrics()` reports `Size` as the writer plus the read handles, and `InUse` / `Waiting` as
+always zero: sqlite3 serializes internally per handle and has no queue of waiting callers.
+
+```ts sample
+import { FrameworkConfiguration } from '@spinajs/configuration';
+import _ from 'lodash';
+
+export class ReadHeavyConfiguration extends FrameworkConfiguration {
+  public async resolve(): Promise<void> {
+    await super.resolve();
+
+    this.Config = _.merge(this.Config, {
+      db: {
+        Connections: [
+          {
+            Name: 'sqlite',
+            Driver: 'orm-driver-sqlite',
+            Filename: './data/app.sqlite',
+            // 1 writer + 7 read-only handles.
+            Pool: { Max: 8 },
+          },
+        ],
+      },
+    });
+  }
+}
+```
+
+## In-memory databases
+
+`Filename: ':memory:'` gives a database that exists only while the connection is open — ideal
+for tests. The read pool is disabled, so it runs on one handle.
+
+```ts sample
+import { FrameworkConfiguration } from '@spinajs/configuration';
+import _ from 'lodash';
+
+export class TestConfiguration extends FrameworkConfiguration {
+  public async resolve(): Promise<void> {
+    await super.resolve();
+
+    this.Config = _.merge(this.Config, {
+      db: {
+        DefaultConnection: 'sqlite',
+        Connections: [
+          {
+            Name: 'sqlite',
+            Driver: 'orm-driver-sqlite',
+            Filename: ':memory:',
+            Migration: { OnStartup: true, Table: 'test_migrations' },
+          },
+        ],
+      },
+    });
+  }
+}
+```
+
+Every `DI.resolve(Orm)` against `:memory:` starts from an empty database, so migrations run each
+time — which is what makes it a clean slate per test run.
+
+## Connection failures
+
+`connect()` drops the handle on a failed open rather than closing it. sqlite3 never invokes the
+close callback for a database that failed to open, so closing there left the connect promise
+unsettled and an app pointed at a bad path, an unreadable file or a missing directory waited
+**forever** instead of being told `SQLITE_CANTOPEN`. sqlite3 has already released whatever it
+allocated for a failed open, so there is nothing to clean up.
+
+The directory containing `Filename` must exist — SQLite creates the file, not the path.
+
+## Transactions
+
+One handle, so `_begin` returns a context with no `connection` and `_dispose` is a no-op.
+Savepoints are real SQLite savepoints, so nesting works.
+
+`SupportedIsolationLevels` is `['SERIALIZABLE']` and nothing else. sqlite3 outside shared-cache
+mode serializes access to the database file, which *is* SERIALIZABLE; any other requested level
+is rejected by the base driver rather than silently ignored.
+
+```ts sample
+import { DI } from '@spinajs/di';
+import { OrmDriver } from '@spinajs/orm';
+
+export async function serializable() {
+  const driver = DI.resolve<OrmDriver>('OrmConnection', ['sqlite'])!;
+
+  // Fine — the only level SQLite declares.
+  return await driver.transaction(async () => driver.select().from('users'), { isolation: 'SERIALIZABLE' });
+}
+```
+
+## Retries
+
+`SQLITE_BUSY` is in the core's `RETRYABLE_ERROR_CODES`, so a write that lost a lock race is
+retried with backoff rather than failing immediately. Tune it through `Resilience`:
+
+```ts sample
+import { FrameworkConfiguration } from '@spinajs/configuration';
+import _ from 'lodash';
+
+export class BusyTolerantConfiguration extends FrameworkConfiguration {
+  public async resolve(): Promise<void> {
+    await super.resolve();
+
+    this.Config = _.merge(this.Config, {
+      db: {
+        Connections: [
+          {
+            Name: 'sqlite',
+            Driver: 'orm-driver-sqlite',
+            Filename: './data/app.sqlite',
+            Resilience: { MaxRetries: 8, RetryDelay: 50, MaxRetryDelay: 2000 },
+          },
+        ],
+      },
+    });
+  }
+}
+```
+
+Remember that retries are suppressed inside a transaction — the connection carried uncommitted
+state, and replaying a statement after reconnecting would apply it outside the transaction.
+
+## Attaching another database
+
+The driver supports `ATTACH`, which lets one connection query across database files.
+
+```ts sample
+import { DI } from '@spinajs/di';
+import { OrmDriver } from '@spinajs/orm';
+
+export async function attach() {
+  const driver = DI.resolve<OrmDriver>('OrmConnection', ['sqlite'])!;
+
+  await driver.schema().raw(`ATTACH DATABASE './data/archive.sqlite' AS archive`);
+
+  return await driver.select().from('archive.orders').where('Status', 'closed');
+}
+```
+
+Attach on the **writer** handle. Read-pool handles are separate connections and do not inherit an
+attachment made on the writer.

--- a/packages/orm-sqlite/docs/02-dialect-notes.md
+++ b/packages/orm-sqlite/docs/02-dialect-notes.md
@@ -1,0 +1,218 @@
+# Dialect notes
+
+## Feature support
+
+```ts
+public supportedFeatures(): ISupportedFeature {
+  return { events: false, insertReturning: true, insertIdIsFirstOfBatch: false };
+}
+```
+
+| Feature | Value | Consequence |
+| --- | --- | --- |
+| `events` | `false` | No database scheduled events. Guard event migrations with `connection.supportedFeatures().events`. |
+| `insertReturning` | **`true`** | The only shipped driver with it. Generated keys come back exactly, including from multi-row inserts. |
+| `insertIdIsFirstOfBatch` | `false` | `sqlite3_last_insert_rowid()` is the **last** rowid, not the first. SQLite opts out of the positional batch backfill — it does not need it, because it has `RETURNING`. |
+
+`SupportedIsolationLevels` is `['SERIALIZABLE']`.
+
+## Type mapping
+
+`SqliteColumnCompiler` maps the ORM's `ColumnType` onto SQLite's four storage classes.
+
+| ORM type | SQLite |
+| --- | --- |
+| `binary`, `tinyblob`, `mediumblob`, `longblob` | `BLOB` |
+| `string`, `text`, `tinytext`, `mediumtext`, `longtext` | `TEXT` |
+| `date`, `dateTime`, `time`, `timestamp` | `TEXT` |
+| `set`, `enum` | `TEXT` |
+| `float`, `double` | `REAL` |
+| `decimal` | `DECIMAL` |
+| `int`, `tinyint`, `smallint`, `mediumint`, `bigint` | `INTEGER` |
+| `boolean` | `BOOLEAN NOT NULL CHECK (col IN (0, 1))` |
+
+Datetimes are stored as ISO-8601 **text**; `SqlDatetimeValueConverter` handles the round-trip.
+`enum` and `set` have no native equivalent — they are text, with `SqlSetConverter` splitting and
+joining on commas. There is no `SET` constraint, so values are not enforced by the database.
+
+Column modifiers are emitted in this order: `UNSIGNED`, `CHARACTER SET`, `COLLATE`, `NOT NULL`,
+`DEFAULT`, `COMMENT`, `PRIMARY KEY`, `AUTOINCREMENT`, `UNIQUE`.
+
+Note `AUTOINCREMENT` — one word, unlike MySQL's `AUTO_INCREMENT`.
+
+## Composite primary keys
+
+SQLite rejects two inline `PRIMARY KEY` column constraints (`table ... has more than one primary
+key`), so `SqliteTableQueryCompiler` clears `InlinePrimaryKey` on every key column and emits a
+table-level constraint instead. That is handled for you.
+
+What is **not** possible: an auto-increment column inside a composite key. `AUTOINCREMENT` is
+only legal on a single `INTEGER PRIMARY KEY`, so the compiler throws rather than emit invalid
+SQL:
+
+```
+sqlite cannot auto-increment column X: it is part of the composite primary key of T
+```
+
+Use `@Primary({ generated: 'uuid' })` or `'assigned'` for composite keys.
+
+## `ALTER TABLE` limitations
+
+SQLite's `ALTER TABLE` supports little beyond adding a column and renaming, and the driver has to
+work around one specific trap.
+
+**Booleans.** `CREATE TABLE` renders a boolean as `BOOLEAN NOT NULL CHECK (col IN (0,1))`. SQLite
+refuses to `ADD COLUMN` a `NOT NULL` column without a non-null default, so that unconditional
+`NOT NULL` makes every boolean add fail against a table that already holds rows.
+`SqliteAddColumnCompiler` therefore drops the `NOT NULL` from the boolean definition, keeps the
+`CHECK` (legal in `ADD COLUMN`, and still enforcing the 0/1 domain), and leaves nullability to
+the ordinary `notNull()` flag. So `.notNull().default().value(0)` still produces a non-nullable
+column:
+
+```ts sample
+import { Migration, OrmMigration, OrmDriver } from '@spinajs/orm';
+
+@Migration('sqlite')
+export class AddFlags_2026_07_27_20_00_00 extends OrmMigration {
+  public async up(connection: OrmDriver): Promise<void> {
+    await connection.schema().alterTable('articles', (table) => {
+      // Works against a populated table: the default makes NOT NULL legal.
+      // `addColumn()` is the default alteration mode, so it can be left off — and it
+      // has to be, if you chain `default()`: `.default().value(x)` returns the base
+      // ColumnQueryBuilder, which no longer carries the alter-mode methods.
+      table.boolean('IsPublished').notNull().default().value(0);
+    });
+  }
+
+  public async down(connection: OrmDriver): Promise<void> {
+    await connection.schema().alterTable('articles', (table) => {
+      table.dropColumn('IsPublished');
+    });
+  }
+}
+```
+
+**`PRIMARY KEY` and `UNIQUE` are deliberately not stripped** from the add path. SQLite cannot add
+such a column at all, and suppressing the clause would silently produce a column *without* the
+constraint the developer asked for. Failing loudly is the right answer; recreate the table
+instead.
+
+## `TRUNCATE`
+
+SQLite has no `TRUNCATE TABLE`. `SqliteTruncateTableQueryCompiler` emits `DELETE FROM <table>`,
+so `Model.truncate()` and `driver.truncate(name)` work — but the auto-increment counter is **not**
+reset, unlike MySQL's `TRUNCATE`.
+
+## Upsert
+
+`SqliteOnDuplicateQueryCompiler` emits `ON CONFLICT (...) DO UPDATE SET ...` rather than MySQL's
+`ON DUPLICATE KEY UPDATE`. SQLite requires an explicit conflict target, so a model with no unique
+or primary key columns throws:
+
+```
+no unique or primary key columns defined in table T
+```
+
+`InsertQueryBuilder.onDuplicate()` defaults the conflict target to the model's `Unique` columns
+when you do not name one.
+
+## `RETURNING`
+
+`SqliteInsertQueryCompiler` appends `RETURNING` to a plain `INSERT`. It is **skipped when an
+upsert clause is present** — the `ON CONFLICT` compiler emits its own `RETURNING`, and two would
+be invalid SQL.
+
+This is what lets SQLite read generated keys back precisely, and why the unit of work does not
+need the positional batch backfill here.
+
+## `ORDER BY`
+
+`SqliteOrderByCompiler` emits **only the first sort entry** — it calls `getSort()`, not
+`getSorts()`. Multi-column ordering is silently reduced to one column on this driver.
+
+```ts sample
+import { Connection, Model, ModelBase, Primary, SortOrder } from '@spinajs/orm';
+
+@Connection('sqlite')
+@Model('articles')
+export class Article extends ModelBase<Article> {
+  @Primary()
+  public Id: number;
+
+  public Views: number;
+
+  public Title: string;
+}
+
+export async function ordering() {
+  // On SQLite this compiles to `ORDER BY Views DESC` only — the Title sort is dropped.
+  return await Article.select().order('Views', SortOrder.DESC).order('Title', SortOrder.ASC);
+}
+```
+
+Use a `RawQuery` in the sort position, or sort in memory, when you need more than one column.
+
+## Joins
+
+`SqlLiteJoinStatement` overrides the generic join. The engine bundled with the sqlite3 Node
+package predates `RIGHT JOIN` support, which is why the core's `Model.populate()` uses a
+`LEFT JOIN` even where a right join would read more naturally.
+
+## `tableInfo`
+
+Reflection uses `PRAGMA table_info`, `PRAGMA index_list` and `PRAGMA foreign_key_list`, producing
+`IColumnDescriptor` entries with `Name`, `Type`, `NativeType`, `Nullable`, `PrimaryKey`,
+`AutoIncrement`, `DefaultValue`, `Unique` and foreign-key details.
+
+Because SQLite's typing is dynamic, `NativeType` reflects the *declared* type, which is what the
+converter type-map matches on.
+
+## `SqliteModelToSqlConverter`
+
+Registered over the standard one. It exists because SQLite's parameter binding accepts a narrower
+set of JavaScript types than the other drivers — values are normalised before binding.
+
+## `SqliteServerResponseMapper`
+
+Reads back:
+
+- a **`RETURNING`** result, which arrives as an array of rows: `RowsAffected` is the row count,
+  `LastInsertId` is the key from the **last** row when there is a single key column and it is
+  numeric, and `Returning` holds the rows;
+- a **plain run**, which carries `{ RowsAffected, LastInsertId }` and no rows.
+
+A `uuid` or `assigned` key is not a number and has no identity semantics, so `LastInsertId`
+reports `0` for it — which is why `RowsAffected` is the only meaningful success signal for those
+strategies.
+
+## Compiler overrides in full
+
+| Token | Implementation |
+| --- | --- |
+| `ColumnQueryCompiler` | `SqliteColumnCompiler` |
+| `AlterColumnQueryCompiler` | `SqliteAlterColumnQueryCompiler` |
+| `TableQueryCompiler` | `SqliteTableQueryCompiler` |
+| `OrderByQueryCompiler` | `SqliteOrderByCompiler` |
+| `JoinStatement` | `SqlLiteJoinStatement` |
+| `OnDuplicateQueryCompiler` | `SqliteOnDuplicateQueryCompiler` |
+| `InsertQueryCompiler` | `SqliteInsertQueryCompiler` |
+| `TableExistsCompiler` | `SqliteTableExistsCompiler` |
+| `DefaultValueBuilder` | `SqlLiteDefaultValueBuilder` |
+| `TruncateTableQueryCompiler` | `SqliteTruncateTableQueryCompiler` |
+| `ModelToSqlConverter` | `SqliteModelToSqlConverter` |
+| `ServerResponseMapper` | `SqliteServerResponseMapper` |
+
+Everything else comes from [`@spinajs/orm-sql`](../../orm-sql/docs/).
+
+## Summary of limitations
+
+| Limitation | Workaround |
+| --- | --- |
+| No database events | Guard with `supportedFeatures().events`. |
+| No `TRUNCATE` (counter not reset) | Accept, or drop and recreate the table. |
+| Multi-column `ORDER BY` reduced to one | Raw SQL, or sort in memory. |
+| No auto-increment in a composite key | `uuid` or `assigned` key generation. |
+| `ALTER TABLE` cannot add `PRIMARY KEY` / `UNIQUE` columns | Recreate the table. |
+| Writes serialize on one handle | Expected; size `Pool.Max` for reads. |
+| `SERIALIZABLE` only | Do not request another level. |
+| Read pool disabled for `:memory:` | Expected — each handle would get its own database. |

--- a/packages/orm-sqlite/docs/README.md
+++ b/packages/orm-sqlite/docs/README.md
@@ -1,0 +1,76 @@
+# `@spinajs/orm-sqlite` documentation
+
+The SQLite dialect driver, built on [`@spinajs/orm-sql`](../../orm-sql/docs/).
+
+| | Page | Covers |
+| --- | --- | --- |
+| 01 | [Configuration](01-configuration.md) | Connection options, the read pool, in-memory databases |
+| 02 | [Dialect notes](02-dialect-notes.md) | Feature support, type mapping, compiler overrides, limitations |
+
+## Quick start
+
+```bash
+npm install @spinajs/orm @spinajs/orm-sqlite
+```
+
+```ts sample
+import { DI } from '@spinajs/di';
+import { Orm } from '@spinajs/orm';
+import { SqliteOrmDriver } from '@spinajs/orm-sqlite';
+
+export async function bootstrap() {
+  DI.register(SqliteOrmDriver).as('orm-driver-sqlite');
+  return await DI.resolve(Orm);
+}
+```
+
+```ts sample
+import { FrameworkConfiguration } from '@spinajs/configuration';
+import _ from 'lodash';
+
+export class AppConfiguration extends FrameworkConfiguration {
+  public async resolve(): Promise<void> {
+    await super.resolve();
+
+    this.Config = _.merge(this.Config, {
+      db: {
+        DefaultConnection: 'sqlite',
+        Connections: [
+          {
+            Name: 'sqlite',
+            Driver: 'orm-driver-sqlite',
+            Filename: './data/app.sqlite',
+            Pool: { Max: 4 },
+            Migration: { OnStartup: true },
+          },
+        ],
+      },
+    });
+  }
+}
+```
+
+## Why SQLite is the odd one out
+
+Three things differ enough from the other drivers to be worth knowing up front:
+
+- **`Pool.Max` sizes a pool of read-only handles**, not writers. SQLite serializes writers at the
+  file level, so extra writer handles buy nothing and invite `SQLITE_BUSY`.
+- **It is the only driver with `RETURNING` support** (`insertReturning: true`), which is how it
+  reads generated keys back exactly — including from multi-row inserts.
+- **`SERIALIZABLE` is the only isolation level**, because sqlite3 outside shared-cache mode
+  serializes access to the file and that *is* SERIALIZABLE.
+
+## Testing
+
+The unit suite needs no server and runs everywhere:
+
+```bash
+cd packages/orm-sqlite && npm test
+```
+
+Integration tests create a temporary on-disk database and remove it afterwards:
+
+```bash
+npm run test:integration
+```

--- a/packages/orm-sqlite/package.json
+++ b/packages/orm-sqlite/package.json
@@ -25,7 +25,7 @@
     "test": "ts-mocha -p tsconfig.json test/*.test.ts",
     "test:integration": "ts-mocha -p tsconfig.json test/integration/**/*.test.ts",
     "coverage": "nyc npm run test",
-    "build-docs": "rimraf docs && typedoc --options typedoc.json src/",
+    "build-docs": "rimraf api-docs && typedoc --options typedoc.json src/",
     "format": "prettier --write \"src/**/*.ts\"",
     "lint": "eslint -c .eslintrc.cjs --ext .ts src --fix",
     "preversion": "npm run lint",

--- a/packages/orm-sqlite/typedoc.json
+++ b/packages/orm-sqlite/typedoc.json
@@ -1,6 +1,6 @@
 {
     "mode": "modules",
-    "out": "docs",
+    "out": "api-docs",
     "name": "spine",
     "theme": "default",
     "ignoreCompilerErrors": "true",

--- a/packages/orm/.gitignore
+++ b/packages/orm/.gitignore
@@ -61,6 +61,6 @@ jspm_packages/
 tsconfig.tsbuildinfo
 
 # doc
-docs
+api-docs
 
 lib

--- a/packages/orm/README.md
+++ b/packages/orm/README.md
@@ -1,11 +1,80 @@
 # `@spinajs/orm`
 
-> TODO: description
+The SpinaJS ORM core: model metadata and decorators, query builders, relations, a unit of work,
+and the schema / migration layer.
+
+It contains **no SQL**. Statements and compilers are declared abstract and resolved from each
+connection's DI container, which is what lets one application run SQLite and MySQL side by side.
+The SQL itself lives in [`@spinajs/orm-sql`](../orm-sql) and the driver packages above it.
+
+## Install
+
+```bash
+npm install @spinajs/orm @spinajs/orm-sqlite
+```
 
 ## Usage
 
-```
-const orm = require('@spinajs/orm');
+```ts
+import { DI } from '@spinajs/di';
+import { Connection, Model, ModelBase, Primary, Orm } from '@spinajs/orm';
+import { SqliteOrmDriver } from '@spinajs/orm-sqlite';
 
-// TODO: DEMONSTRATE API
+@Connection('default')
+@Model('users')
+export class User extends ModelBase<User> {
+  @Primary()
+  public Id: number;
+
+  public Email: string;
+}
+
+DI.register(SqliteOrmDriver).as('orm-driver-sqlite');
+await DI.resolve(Orm);
+
+const user = await User.getOrCreate(null, { Email: 'someone@example.com' });
+const recent = await User.where('Email', 'like', '%@example.com').take(10);
+```
+
+Connections are declared under the `db` key of `@spinajs/configuration`. Resolving `Orm` opens
+them, runs pending migrations, reflects each table's columns onto its model, and installs the
+static methods used above.
+
+## Documentation
+
+Full documentation lives in **[docs/](docs/)**.
+
+| | Page |
+| --- | --- |
+| 01 | [Getting started](docs/01-getting-started.md) |
+| 02 | [Configuration](docs/02-configuration.md) |
+| 03 | [Models and decorators](docs/03-models-and-decorators.md) |
+| 04 | [Static model API](docs/04-static-model-api.md) |
+| 05 | [Instance API](docs/05-instance-api.md) |
+| 06 | [Query builder](docs/06-query-builder.md) |
+| 07 | [Relations](docs/07-relations.md) |
+| 08 | [Unit of work](docs/08-unit-of-work.md) |
+| 09 | [Transactions](docs/09-transactions.md) |
+| 10 | [Schema and migrations](docs/10-schema-and-migrations.md) |
+| 11 | [Converters and hydration](docs/11-converters-and-hydration.md) |
+| 12 | [Architecture](docs/12-architecture.md) |
+| 13 | [Observability](docs/13-observability.md) |
+
+## Related packages
+
+| Package | Purpose |
+| --- | --- |
+| [`@spinajs/orm-sql`](../orm-sql) | Shared SQL statements and compilers |
+| [`@spinajs/orm-sqlite`](../orm-sqlite) | SQLite driver |
+| [`@spinajs/orm-mysql`](../orm-mysql) | MySQL / MariaDB driver |
+| [`@spinajs/orm-mssql`](../orm-mssql) | SQL Server driver |
+| [`@spinajs/orm-http`](../orm-http) | Route arguments, filtering and DTO relations for `@spinajs/http` |
+| [`@spinajs/orm-api`](../orm-api) | CRUD controller building blocks |
+
+## Development
+
+```bash
+npm test                    # unit suite, no database required
+npm run build               # compile to lib/
+npm run docs:check          # from the repo root: type-check every documentation sample
 ```

--- a/packages/orm/docs/01-getting-started.md
+++ b/packages/orm/docs/01-getting-started.md
@@ -1,0 +1,195 @@
+# Getting started
+
+## Install
+
+The core alone has no dialect. Install it together with a driver.
+
+```bash
+npm install @spinajs/orm @spinajs/orm-sqlite
+```
+
+`@spinajs/orm-sql` comes in as a dependency of every driver — you rarely install it directly.
+
+## The three moving parts
+
+1. **Configuration** declares connections under `db.Connections`.
+2. **`Orm`** is a DI service. Resolving it opens every connection, discovers models and
+   migrations, runs pending migrations, and reflects each table's columns back onto its model.
+3. **Models** are classes decorated with `@Model` and `@Connection`.
+
+Nothing works before `Orm` has resolved — a model's static methods are installed onto the class
+*by* `Orm.resolve()`, so calling `User.where(...)` beforehand throws `Not implemented`.
+
+## Configure a connection
+
+Connections live under the `db` key. The driver name is a DI registration key, not a package
+name — that is why the driver class has to be registered before `Orm` resolves.
+
+```ts sample
+import { FrameworkConfiguration } from '@spinajs/configuration';
+import { MigrationTransactionMode } from '@spinajs/orm';
+import _ from 'lodash';
+
+export class AppConfiguration extends FrameworkConfiguration {
+  public async resolve(): Promise<void> {
+    await super.resolve();
+
+    this.Config = _.merge(this.Config, {
+      db: {
+        // Name of the connection that answers to `@Connection('default')`.
+        DefaultConnection: 'main',
+        Connections: [
+          {
+            Name: 'main',
+            Driver: 'orm-driver-sqlite',
+            Filename: './data/app.sqlite',
+            Migration: {
+              OnStartup: true,
+              Transaction: { Mode: MigrationTransactionMode.PerMigration },
+            },
+          },
+        ],
+      },
+    });
+  }
+}
+```
+
+Every option is listed in [02-configuration.md](02-configuration.md).
+
+## Bootstrap
+
+```ts sample
+import { DI } from '@spinajs/di';
+import { Configuration } from '@spinajs/configuration-common';
+import { FrameworkConfiguration } from '@spinajs/configuration';
+import { Orm } from '@spinajs/orm';
+import { SqliteOrmDriver } from '@spinajs/orm-sqlite';
+
+export class AppConfig extends FrameworkConfiguration {}
+
+export async function bootstrap(): Promise<Orm> {
+  DI.register(AppConfig).as(Configuration);
+
+  // The `Driver` string in the connection config resolves against this registration.
+  DI.register(SqliteOrmDriver).as('orm-driver-sqlite');
+
+  // Opens connections, runs migrations, reflects table info, installs model statics.
+  return await DI.resolve(Orm);
+}
+```
+
+`DI.resolve(Orm)` is idempotent — `Orm` is a service, so the second call returns the same
+instance. Call `orm.dispose()` on shutdown to stop the health checks and close the pools.
+
+## Write a migration
+
+A migration's class name must end in a `yyyy_MM_dd_HH_mm_ss` stamp; the ORM parses it to order
+migrations and refuses to load one that does not match.
+
+```ts sample
+import { Migration, OrmMigration, OrmDriver } from '@spinajs/orm';
+
+@Migration('main')
+export class CreateUsers_2026_07_27_09_00_00 extends OrmMigration {
+  public async up(connection: OrmDriver): Promise<void> {
+    await connection.schema().createTable('users', (table) => {
+      table.int('Id').primaryKey().autoIncrement();
+      table.string('Email', 255).notNull().unique();
+      table.string('Name', 128).notNull();
+      table.dateTime('CreatedAt').notNull();
+      table.dateTime('DeletedAt');
+    });
+  }
+
+  public async down(connection: OrmDriver): Promise<void> {
+    await connection.schema().dropTable('users');
+  }
+}
+```
+
+`@Migration('main')` registers the class under the `__migrations__` DI key and binds it to the
+`main` connection. See [10-schema-and-migrations.md](10-schema-and-migrations.md) for the whole
+schema-builder surface and the migration lifecycle.
+
+## Define a model
+
+The column list is **not** taken from the class. `Orm.resolve()` reflects the real table with
+`driver.tableInfo()` and merges the result with whatever the decorators declared. A property
+with no decorator is still a column as long as the database has one by that name.
+
+```ts sample
+import { Connection, Model, ModelBase, Primary, CreatedAt, SoftDelete } from '@spinajs/orm';
+import { DateTime } from 'luxon';
+
+@Connection('main')
+@Model('users')
+export class User extends ModelBase<User> {
+  @Primary()
+  public Id: number;
+
+  public Email: string;
+
+  public Name: string;
+
+  @CreatedAt()
+  public CreatedAt: DateTime;
+
+  @SoftDelete()
+  public DeletedAt: DateTime;
+}
+```
+
+`@Model` registers the class under the `__models__` DI key, which is how `Orm` finds it without
+an explicit import list.
+
+## Query
+
+```ts sample
+import { Connection, Model, ModelBase, Primary } from '@spinajs/orm';
+
+@Connection('main')
+@Model('users')
+export class User extends ModelBase<User> {
+  @Primary()
+  public Id: number;
+
+  public Email: string;
+
+  public Name: string;
+}
+
+export async function queries() {
+  // One row by primary key. `get` resolves undefined when missing, `getOrFail` throws.
+  const byId = await User.get(1);
+
+  // A builder is thenable — awaiting it executes it. It executes at most once.
+  const admins = await User.where('Email', 'like', '%@admin.example').take(20);
+
+  // Aggregates.
+  const total = await User.count();
+
+  // Insert one row and read the generated key back off the instance.
+  const fresh = new User({ Email: 'new@example.com', Name: 'New' });
+  await fresh.insert();
+
+  return { byId, admins, total, id: fresh.Id };
+}
+```
+
+## What to read next
+
+- Adding relations → [07-relations.md](07-relations.md)
+- Saving a whole object graph in one transaction → [08-unit-of-work.md](08-unit-of-work.md)
+- The full query surface → [06-query-builder.md](06-query-builder.md)
+
+## Common first-run failures
+
+| Message | Cause |
+| --- | --- |
+| `ORM connection driver orm-driver-x not registerd` | The driver class was not registered under the string used in `Driver`. |
+| `Not implemented` from a static method | `Orm` has not resolved yet, so `MODEL_STATIC_MIXINS` were never installed. |
+| `model X does not have model descriptor. Use @model decorator on class` | `@Model` missing on the class. |
+| `type Y not found for relation R in model X` | The relation's target model was never discovered — it needs `@Model` too. |
+| `Migration file F have invalid name format` | The class name has no `yyyy_MM_dd_HH_mm_ss` suffix. |
+| `Cannot find connection C in connection list` | The model's `@Connection` name is not in `db.Connections` (nor an alias). |

--- a/packages/orm/docs/02-configuration.md
+++ b/packages/orm/docs/02-configuration.md
@@ -1,0 +1,217 @@
+# Configuration
+
+Everything the ORM reads lives under the `db` key of `@spinajs/configuration`.
+
+```ts sample
+import { FrameworkConfiguration } from '@spinajs/configuration';
+import { MigrationTransactionMode } from '@spinajs/orm';
+import _ from 'lodash';
+
+export class AppConfiguration extends FrameworkConfiguration {
+  public async resolve(): Promise<void> {
+    await super.resolve();
+
+    this.Config = _.merge(this.Config, {
+      db: {
+        DefaultConnection: 'main',
+        Aliases: {
+          'db-user-session': 'main',
+        },
+        Connections: [
+          {
+            Name: 'main',
+            Driver: 'orm-driver-mysql',
+            Host: '127.0.0.1',
+            Port: 3306,
+            User: 'app',
+            Password: 'secret',
+            Database: 'app',
+            Encoding: 'utf8mb4',
+            Pool: { Min: 2, Max: 20, IdleTimeout: 30000, AcquireTimeout: 10000 },
+            Resilience: { HealthCheckInterval: 30000, MaxRetries: 5, RetryDelay: 200, MaxRetryDelay: 5000 },
+            Migration: {
+              OnStartup: true,
+              Table: 'spinajs_migration',
+              Transaction: { Mode: MigrationTransactionMode.PerMigration },
+            },
+          },
+        ],
+      },
+    });
+  }
+}
+```
+
+## Top-level `db` keys
+
+| Key | Type | Meaning |
+| --- | --- | --- |
+| `db.Connections` | `IDriverOptions[]` | The connections to open. Defaults to `[]`. |
+| `db.DefaultConnection` | `string` | Name of an existing connection that is additionally registered under the name `default`. Throws if the named connection does not exist. |
+| `db.Aliases` | `Record<string, string>` | Extra names for existing connections. Each value must name a connection already in the list. |
+
+Aliases exist so a module that hard-codes a connection name (`db-user-session`, say) can be
+pointed at a connection you already have rather than forcing a second one open.
+
+## `IDriverOptions`
+
+### Identity
+
+| Option | Type | Default | Meaning |
+| --- | --- | --- | --- |
+| `Name` | `string` | — | Connection name. This is what `@Connection('...')` refers to. |
+| `Driver` | `string` | — | DI key the driver class was registered under, e.g. `orm-driver-mysql`. Resolving fails loudly if nothing is registered under it. |
+| `Database` | `string` | — | Database / schema name. |
+| `User`, `Password`, `Host`, `Port` | | — | Server credentials. |
+| `Encoding` | `string` | — | Connection charset. |
+| `Filename` | `string` | — | Database file, for file-backed dialects (SQLite). |
+| `Options` | `any` | — | Passed through to the underlying driver library untouched. |
+
+`Name`, `Driver`, `Database`, `User`, `Host`, `Port` and `Filename` are the only options echoed
+into connection log lines — `Password` is never logged.
+
+### Pooling — `Pool`
+
+| Option | Default | Meaning |
+| --- | --- | --- |
+| `Min` | `0` | Connections kept open while idle. |
+| `Max` | `10` | Maximum concurrent connections. |
+| `IdleTimeout` | `30000` | Milliseconds an idle connection is kept before closing. |
+| `AcquireTimeout` | `10000` | Milliseconds to wait for a free connection before failing. |
+
+`PoolLimit` is the deprecated predecessor of `Pool.Max` and is still honoured when `Pool.Max` is
+absent. Resolution order is `Pool.Max` → `PoolLimit` → `10`.
+
+SQLite treats `Pool.Max` differently: writes always serialize on one handle because SQLite locks
+at the file level, so `Max` sizes a pool of `Max - 1` **read-only** handles instead. It is
+ignored entirely for `:memory:` and anonymous temporary databases, where each handle would open
+its own private database. See [orm-sqlite's docs](../../orm-sqlite/docs/).
+
+### Resilience — `Resilience`
+
+| Option | Default | Meaning |
+| --- | --- | --- |
+| `HealthCheckInterval` | `30000` | Milliseconds between health probes. `0` disables the probe. |
+| `MaxRetries` | `5` | Reconnect attempts after a transport failure. |
+| `RetryDelay` | `200` | Base backoff in milliseconds. |
+| `MaxRetryDelay` | `5000` | Backoff ceiling. |
+
+Only transport failures are retried. A malformed statement or a constraint violation propagates
+on the first attempt. Details in [13-observability.md](13-observability.md).
+
+### Migrations — `Migration`
+
+| Option | Default | Meaning |
+| --- | --- | --- |
+| `OnStartup` | `false` | Run pending migrations when `Orm` resolves. |
+| `Table` | `spinajs_migration` | Table recording applied migrations. Created automatically if absent. |
+| `Transaction.Mode` | `None` | `MigrationTransactionMode.PerMigration` wraps each migration in its own transaction; `None` runs them bare. |
+
+`OnStartup: false` only suppresses the *automatic* run. An explicit `orm.migrateUp()` passes
+`force = true` and runs regardless — that is how the CLI and tests migrate on demand.
+
+### SQL dialect details
+
+| Option | Default | Meaning |
+| --- | --- | --- |
+| `AliasSeparator` | `$` (`#` on MSSQL) | Character wrapping generated table aliases. MSSQL overrides it because `$` starts a pseudo-column there. |
+| `DefaultConnection` | `false` | Present on the options interface, but the ORM decides the default connection from the top-level `db.DefaultConnection` string. Setting it per connection has no effect. |
+
+Generated aliases look like `SELECT $users$.Name FROM users as $users$`.
+
+### SSH tunnelling — `SSH`
+
+Only `MySqlSSHOrmDriver` acts on it.
+
+```ts sample
+import { IDriverOptions } from '@spinajs/orm';
+
+export const tunnelled: IDriverOptions = {
+  Name: 'remote',
+  Driver: 'orm-driver-mysql-ssh',
+  Host: '127.0.0.1',
+  Port: 3306,
+  Database: 'app',
+  SSH: {
+    Host: 'bastion.example.com',
+    Port: 22,
+    User: 'deploy',
+    PrivateKey: '/home/deploy/.ssh/id_rsa',
+  },
+};
+```
+
+## Model and migration discovery
+
+Models and migrations are **not** found by scanning directories from ORM configuration. They
+register themselves with DI when their decorator runs:
+
+- `@Model(table)` → `DI.register(target).as('__models__')`
+- `@Migration(connection)` → `DI.register(target).as('__migrations__')`
+
+`Orm.resolve()` then reads back `DI.getRegisteredTypes('__models__')` and
+`DI.getRegisteredTypes('__migrations__')`. The practical consequence is that **a model file has
+to be imported before `Orm` resolves**, or the decorator never runs and the model is invisible.
+Applications normally arrange this through `@spinajs/configuration`'s `system.dirs` file
+discovery, or by importing an index module.
+
+## What `Orm.resolve()` does, in order
+
+1. `createConnections()` — resolve each driver, `connect()`, store it, start its health check.
+   Then register `db.DefaultConnection` under `default` and wire `db.Aliases`. Finally register
+   an `OrmConnection` DI factory so any module can fetch a driver by name.
+2. Register every `__migrations__` and `__models__` type it finds.
+3. `migrateUp(undefined, false)` — apply pending migrations for connections with
+   `Migration.OnStartup`.
+4. Register the default value converters (`DateTime`/`Date` → datetime, `Boolean`/`Bool` →
+   boolean, `Time`/`TimeSpan` → time) into `__orm_db_value_converters__`.
+5. `reloadTableInfo()` — for each model, call `driver.tableInfo()`, merge the reflected columns
+   over the decorator-declared ones, attach converters, mark relation foreign keys, and build
+   `descriptor.Schema` via `buildModelJsonSchema`.
+6. `wireRelations()` — resolve every relation's `TargetModelType` (a class, a forward ref or a
+   model *name*) to a concrete class. Throws if a target was never registered.
+7. `applyModelMixins()` — bind `MODEL_STATIC_MIXINS` onto every model class. **This is the step
+   that makes `User.where(...)` work.**
+8. Run each freshly applied migration's `data()` hook, now that models are usable.
+
+## Getting a connection at runtime
+
+```ts sample
+import { DI } from '@spinajs/di';
+import { Orm, OrmDriver } from '@spinajs/orm';
+
+export async function connections() {
+  // By name, through the factory Orm registers during resolve().
+  const main = DI.resolve<OrmDriver>('OrmConnection', ['main']);
+
+  // Or straight off the Orm service.
+  const orm = DI.get<Orm>('Orm');
+  const same = orm?.Connections.get('main');
+
+  return { main, same };
+}
+```
+
+`DI.resolve('OrmConnection', [name])` returns `null` for an unknown name rather than throwing.
+
+## Multiple connections
+
+A model belongs to exactly one connection, named by `@Connection`. A model with no
+`@Connection` has `Connection: null` in its descriptor and will fail to find a driver.
+
+One thing the unit of work enforces: `save()` refuses to persist a graph that spans two
+connections, because its transaction only covers one of them. Save each connection's graph
+separately.
+
+## Disposal
+
+```ts sample
+import { DI } from '@spinajs/di';
+import { Orm } from '@spinajs/orm';
+
+export async function shutdown() {
+  const orm = DI.get<Orm>('Orm');
+  // Stops every health-check timer and disconnects every connection.
+  await orm?.dispose();
+}
+```

--- a/packages/orm/docs/03-models-and-decorators.md
+++ b/packages/orm/docs/03-models-and-decorators.md
@@ -1,0 +1,357 @@
+# Models and decorators
+
+A model is a class extending `ModelBase` carrying `@Model` and `@Connection`. Everything the
+ORM knows about it lives in an `IModelDescriptor` stored as *own* metadata on the class under
+the `MODEL_DESCTRIPTION_SYMBOL` key.
+
+## The model descriptor
+
+Read it with `Model.getModelDescriptor()` (static, installed by `Orm`) or
+`extractModelDescriptor(SomeClass)`.
+
+| Field | Meaning |
+| --- | --- |
+| `Name` | The class's own name. Never inherited. |
+| `TableName` | From `@Model`. |
+| `Connection` | From `@Connection`. |
+| `PrimaryKey` | `string[]` — key columns in decorator-evaluation order. Empty when no `@Primary`. |
+| `PrimaryKeyGeneration` | `Map<column, 'auto' \| 'uuid' \| 'assigned'>`. |
+| `Columns` | `IColumnDescriptor[]`. Reflected from the database and merged with decorator declarations. |
+| `Converters` | `Map<column, IValueConverterDescriptor>` from the converter decorators. |
+| `Relations` | `Map<name, IRelationDescriptor>`. |
+| `Timestamps` | `{ CreatedAt, UpdatedAt }` column names, `''` when unset. |
+| `SoftDelete` | `{ DeletedAt }` column name. |
+| `Archived` | `{ ArchivedAt }` column name. |
+| `DiscriminationMap` | `{ Field, Models }`. |
+| `JunctionModelProperties` | From `@JunctionTable`. |
+| `Driver` | The resolved `OrmDriver`, assigned during `reloadTableInfo()`. |
+| `Schema` | JSON schema built from the columns — see [11-converters-and-hydration.md](11-converters-and-hydration.md). |
+
+`PrimaryKey` is an **array**. A single-column key is a one-element array. Code that treats it as
+a string will compile a column name of `0` — this is the single most common porting mistake.
+
+## Class-level decorators
+
+### `@Model(tableName)`
+
+Binds the class to a table and registers it under the `__models__` DI key so `Orm` discovers it.
+
+### `@Connection(name)`
+
+Names the connection from `db.Connections` (or an alias, or `default`).
+
+### `@DiscriminationMap(fieldName, entries)`
+
+Creates a different concrete model per value of a column — single-table inheritance.
+
+```ts sample
+import { Connection, Model, ModelBase, Primary, DiscriminationMap } from '@spinajs/orm';
+
+@Connection('default')
+@Model('animals')
+export class Cat extends ModelBase {
+  @Primary()
+  public Id: number;
+
+  public Kind: string;
+}
+
+@Connection('default')
+@Model('animals')
+export class Dog extends ModelBase {
+  @Primary()
+  public Id: number;
+
+  public Kind: string;
+}
+
+@Connection('default')
+@Model('animals')
+@DiscriminationMap('Kind', [
+  { Key: 'cat', Value: Cat },
+  { Key: 'dog', Value: Dog },
+])
+export class Animal extends ModelBase {
+  @Primary()
+  public Id: number;
+
+  public Kind: string;
+}
+```
+
+Selecting `Animal` now yields `Cat` and `Dog` instances according to each row's `Kind`. The
+switch happens in `DiscriminationMapMiddleware`, which is registered on the builder by
+`createQuery` whenever the descriptor has a `DiscriminationMap.Field`.
+
+### `@Migration(connectionName)`
+
+Marks an `OrmMigration` subclass and registers it under `__migrations__`. Covered in
+[10-schema-and-migrations.md](10-schema-and-migrations.md).
+
+## Primary keys
+
+### `@Primary(options?)`
+
+Marks a column as part of the key. Apply it to more than one property to declare a composite
+key; the column order is decorator-evaluation order.
+
+```ts sample
+import { Connection, Model, ModelBase, Primary } from '@spinajs/orm';
+
+@Connection('default')
+@Model('composite_table')
+export class TenantRecord extends ModelBase {
+  @Primary()
+  public TenantId: number;
+
+  @Primary()
+  public Code: string;
+
+  public Name: string;
+}
+```
+
+`options.generated` picks the generation strategy:
+
+| Strategy | Behaviour |
+| --- | --- |
+| `auto` (default) | The database assigns it — identity / auto-increment. Read back after insert via `RETURNING` where supported, otherwise from the reported insert id. |
+| `uuid` | Generated client-side at **construction**, so the value is available before the row reaches the database. |
+| `assigned` | The caller supplies it. Inserting without one throws before any SQL is built. |
+
+```ts sample
+import { Connection, Model, ModelBase, Primary } from '@spinajs/orm';
+
+@Connection('default')
+@Model('uuid_key_model')
+export class Document extends ModelBase {
+  @Primary({ generated: 'uuid' })
+  public Id: string;
+
+  public Name: string;
+}
+
+@Connection('default')
+@Model('assigned_key_model')
+export class CountryCode extends ModelBase {
+  @Primary({ generated: 'assigned' })
+  public Code: string;
+
+  public Name: string;
+}
+```
+
+`@Primary()` is **additive across inheritance**. A subclass cannot replace a base class's key,
+only extend it — declare `@Primary()` on every key column of the concrete model.
+
+## Column decorators
+
+### `@Uuid()`
+
+Marks a column as a UUID. A fresh value is generated in `setDefaults()` at construction, and
+`UuidConverter` stores it as a 16-byte `BINARY` and reads it back as the canonical dashed form.
+Pair it with `table.uuid('Col')` in the migration, which is an alias for `binary(name, 16)`.
+
+### `@Ignore()`
+
+Excludes the column from JSON serialization / dehydration. It is still read and written.
+
+### `@JunctionTable()`
+
+Names a property that carries the junction row of a many-to-many relation, so the extra columns
+on the join table are hydrated too. The property's type is read via `design:type` metadata.
+
+## Timestamp and lifecycle decorators
+
+All four require the property to be typed `DateTime` (luxon) — they throw at decoration time
+otherwise — and each attaches `DatetimeValueConverter` to the column.
+
+| Decorator | Effect |
+| --- | --- |
+| `@CreatedAt()` | Set to `DateTime.now()` in the constructor. Enables `Model.newest()` / `Model.oldest()`. |
+| `@UpdatedAt()` | Stamped by `instance.update()` whenever something is actually written. |
+| `@SoftDelete()` | `destroy()` stamps the column instead of deleting; selects filter the row out unless you call `.withDeleted()`. |
+| `@Archived()` | `archive()` stamps the column. |
+
+```ts sample
+import { Connection, Model, ModelBase, Primary, CreatedAt, UpdatedAt, SoftDelete } from '@spinajs/orm';
+import { DateTime } from 'luxon';
+
+@Connection('default')
+@Model('articles')
+export class Article extends ModelBase<Article> {
+  @Primary()
+  public Id: number;
+
+  public Title: string;
+
+  @CreatedAt()
+  public CreatedAt: DateTime;
+
+  @UpdatedAt()
+  public UpdatedAt: DateTime;
+
+  @SoftDelete()
+  public DeletedAt: DateTime;
+}
+
+export async function softDelete() {
+  const article = await Article.getOrFail(1);
+
+  // UPDATE articles SET DeletedAt = now() WHERE Id = 1
+  await article.destroy();
+
+  const visible = await Article.select();               // excludes the row
+  const everything = await Article.select().withDeleted(); // includes it
+
+  return { visible, everything };
+}
+```
+
+## Type / converter decorators
+
+| Decorator | Converter | Notes |
+| --- | --- | --- |
+| `@DateTime()` | `DatetimeValueConverter` | Property must be luxon `DateTime`. Throws if the column already has a converter. |
+| `@Json()` | `JsonValueConverter` | For a **string** column holding JSON. Do *not* use it for a native JSON column — those are detected automatically from the reflected type. |
+| `@Set()` | `SetValueConverter` | Property must be an `Array`. Emulates MySQL `SET`. Throws if a converter is already attached. |
+| `@UniversalConverter(typeColumn?)` | `UniversalValueConverter` | For "type column" tables: a text column whose runtime type is decided by a sibling column, `Type` by default. |
+
+```ts sample
+import { Connection, Model, ModelBase, Primary, Json, Set as SetColumn, UniversalConverter } from '@spinajs/orm';
+
+@Connection('default')
+@Model('user_metadata')
+export class UserMetadata extends ModelBase {
+  @Primary()
+  public Id: number;
+
+  @Json()
+  public Payload: { theme: string; density: number };
+
+  @SetColumn()
+  public Flags: string[];
+
+  /** Runtime type of `Value` is read from the `Type` column. */
+  public Type: string;
+
+  @UniversalConverter('Type')
+  public Value: unknown;
+}
+```
+
+## Inheritance
+
+Descriptors are collapsed down the prototype chain by `@spinajs/di`'s
+`getInheritedDescriptor`, so a subclass inherits its base's columns, relations and options.
+
+Two rules follow from how that merge works, and both matter in practice:
+
+**`Name` is never inherited.** It is reassigned to the class's own name on every descriptor
+access, because the merger would otherwise keep the parent's non-empty name over the child's
+default `''`.
+
+**Inherited members are detached before the first decorator mutates them.** The merger rebuilds
+`Columns` and `Relations` one level deep, but their *elements* stay shared by reference with the
+parent. Decorators like `@Ignore`, `@Uuid` and `@Recursive` mutate a found element in place,
+which on an inherited member would write straight through to the base model's descriptor. The
+first decorator to touch a class therefore runs `detachInheritedModelMembers`, giving it its own
+shallow copies of `Columns`, `Relations`, `Timestamps`, `SoftDelete`, `Archived` and
+`DiscriminationMap`.
+
+Relations are copied with `Object.getOwnPropertyDescriptors` rather than a spread, deliberately:
+a relation descriptor may carry a lazily-defined `PrimaryKey` **accessor** (from `@BelongsTo` or
+`@HasManyToMany` given a model *name*), and spreading would invoke that getter at decoration
+time — when the `Orm` service does not exist yet — freezing the result into a plain value.
+
+```ts sample
+import { Connection, Model, ModelBase, Primary, Ignore } from '@spinajs/orm';
+
+export abstract class AuditedBase extends ModelBase {
+  @Primary()
+  public Id: number;
+
+  public CreatedBy: string;
+}
+
+@Connection('default')
+@Model('invoices')
+export class Invoice extends AuditedBase {
+  public Total: number;
+
+  // Marks Invoice's own copy of the column — AuditedBase is untouched.
+  @Ignore()
+  public InternalNote: string;
+}
+```
+
+## Writing the descriptor by hand
+
+`updateModelDescriptor` is the supported way to mutate a descriptor outside a decorator. It
+routes through `getInheritedDescriptor`, so the write lands on the class's own descriptor and
+cannot leak into its base.
+
+```ts sample
+import { Connection, Model, ModelBase, Primary, updateModelDescriptor } from '@spinajs/orm';
+
+@Connection('default')
+@Model('widgets')
+export class Widget extends ModelBase {
+  @Primary()
+  public Id: number;
+
+  public Label: string;
+}
+
+updateModelDescriptor(Widget, (descriptor) => {
+  descriptor.Columns.push({
+    Name: 'ComputedLabel',
+    Type: 'string',
+    MaxLength: 0,
+    Comment: '',
+    DefaultValue: null,
+    NativeType: '',
+    Unsigned: false,
+    Nullable: true,
+    PrimaryKey: false,
+    AutoIncrement: false,
+    Converter: null,
+    Schema: null,
+    Unique: false,
+    Uuid: false,
+    Ignore: false,
+    Aggregate: false,
+    Virtual: true,
+    IsForeignKey: false,
+    ForeignKeyDescription: null,
+  });
+});
+```
+
+`_prepareColumnDesc` fills the same defaults for you when you only care about a couple of
+fields.
+
+## Column descriptor reference
+
+Every column carries an `IColumnDescriptor`. Most fields are reflected from the database by
+`driver.tableInfo()`; a few are set by decorators.
+
+| Field | Source | Meaning |
+| --- | --- | --- |
+| `Name` | both | Column name. |
+| `Type` | reflected | Normalized type (`int`, `string`, `dateTime`, …). |
+| `NativeType` | reflected | Full database type, e.g. `int(10) unsigned`. Empty for a column the database has not been asked about. |
+| `MaxLength`, `Unsigned`, `Nullable`, `DefaultValue`, `Comment` | reflected | As declared in the database. |
+| `PrimaryKey`, `AutoIncrement`, `Unique` | reflected | Constraint flags. |
+| `Converter` | resolved | Value converter instance, from a decorator or the type map. |
+| `Uuid` | `@Uuid` | Generate a UUID at construction. |
+| `Ignore` | `@Ignore` | Skip during serialization. |
+| `Virtual` | decorator | Not a real database column; excluded from `SELECT` column lists. |
+| `Aggregate` | decorator | Produced by an aggregate expression. |
+| `IsForeignKey` / `ForeignKeyDescription` | reflected + relations | Marked for any column named by a relation's `ForeignKey`. |
+| `Schema` | built | JSON-schema fragment for this column. |
+
+`Nullable` deserves a warning: `_prepareColumnDesc` defaults it to `false`, so a model whose
+table info has not been loaded reports *every* column as non-nullable. Code that reasons about
+nullability must check `NativeType` is non-empty first — which is exactly what
+`resolveOrphanPolicy` does.

--- a/packages/orm/docs/04-static-model-api.md
+++ b/packages/orm/docs/04-static-model-api.md
@@ -1,0 +1,441 @@
+# Static model API
+
+Every model class gains a set of static methods. They are **not** declared on `ModelBase` in any
+working form — the versions there throw `Not implemented` and exist only to give TypeScript the
+signatures. `Orm.resolve()` overwrites them by binding `MODEL_STATIC_MIXINS` onto each
+registered model class.
+
+The practical consequence: **a static call before `Orm` has resolved throws `Not implemented`.**
+
+Most of these return a query builder rather than a promise. A builder is thenable, so `await`
+executes it — but you can keep chaining until you do. Methods that return a `Promise` directly
+are marked below.
+
+## Metadata
+
+### `getModelDescriptor(): IModelDescriptor`
+
+The model's descriptor. Throws `OrmException` if the class has none (missing `@Model`).
+
+### `getRelationDescriptor(name: string): IRelationDescriptor`
+
+One relation's descriptor. The lookup is **case-insensitive and trims** the argument — a
+backward-compatibility concession, not a design intent. Throws if the relation does not exist.
+
+### `driver(): OrmDriver`
+
+The driver for this model's connection. Throws if the connection name is not configured.
+
+## Reading
+
+### `query()`
+
+A bare `SelectQueryBuilder` with **no columns selected**. Use it when you want to choose columns
+yourself, or for joins and raw projections.
+
+### `select()`
+
+`query()` plus `select('*')`.
+
+### `where(...)`
+
+`select('*')` plus a where clause. Accepts every form the where builder does — see
+[06-query-builder.md](06-query-builder.md).
+
+```ts sample
+import { Connection, Model, ModelBase, Primary, RawQuery } from '@spinajs/orm';
+
+@Connection('default')
+@Model('users')
+export class User extends ModelBase<User> {
+  @Primary()
+  public Id: number;
+
+  public Email: string;
+
+  public Name: string;
+
+  public Age: number;
+}
+
+export async function reading() {
+  const byColumn = await User.where('Email', 'someone@example.com');
+  const withOperator = await User.where('Age', '>', 30);
+  const byObject = await User.where({ Name: 'Ada', Age: 36 });
+  const nested = await User.where(function () {
+    this.where('Age', '>', 18).orWhere('Name', 'like', 'A%');
+  });
+  const raw = await User.where(RawQuery.create('LENGTH(Name) > ?', [5]));
+
+  return { byColumn, withOperator, byObject, nested, raw };
+}
+```
+
+### `all(page?, perPage?)`
+
+`select('*')`, with `take(perPage).skip(page * perPage)` applied when **both** arguments are
+given and valid (`page >= 0`, `perPage > 0`). Pages are zero-based.
+
+```ts sample
+import { Connection, Model, ModelBase, Primary } from '@spinajs/orm';
+
+@Connection('default')
+@Model('users')
+export class User extends ModelBase<User> {
+  @Primary()
+  public Id: number;
+
+  public Name: string;
+}
+
+export async function paging() {
+  const everyone = await User.all();
+  const thirdPage = await User.all(2, 25); // rows 50..74
+  return { everyone, thirdPage };
+}
+```
+
+### `find(pks: any[])` → `Promise`
+
+Rows for the given primary keys. Composite keys are passed as tuples.
+
+### `findOrFail(pks: any[])` → `Promise`
+
+Same, but throws when the result count does not match the requested count.
+
+### `get(pk)` → `Promise`
+
+One row by primary key, or `undefined`. Applies a deterministic ordering first (see *Ordering
+fallback* below).
+
+### `getOrFail(pk)` → `Promise`
+
+Same, but throws `OrmNotFoundException` when missing.
+
+```ts sample
+import { Connection, Model, ModelBase, Primary } from '@spinajs/orm';
+
+@Connection('default')
+@Model('composite_table')
+export class TenantRecord extends ModelBase {
+  @Primary()
+  public TenantId: number;
+
+  @Primary()
+  public Code: string;
+
+  public Name: string;
+}
+
+export async function keys() {
+  const one = await TenantRecord.get([1, 'AB']);          // composite key as a tuple
+  const many = await TenantRecord.find([[1, 'AB'], [2, 'CD']]);
+  const strict = await TenantRecord.findOrFail([[1, 'AB']]);
+
+  return { one, many, strict };
+}
+```
+
+### `first(callback?)` / `last(callback?)` → `Promise`
+
+The first / last row by the fallback ordering. The callback receives the where builder.
+
+### `newest(callback?)` / `oldest(callback?)` → `Promise`
+
+Ordered by the `@CreatedAt` column. Throws `OrmException` when the model has none.
+
+### `count(callback?)` → `Promise<number>`
+
+`COUNT(*)` aliased `count`, read back as raw data. Resolves `0` rather than `undefined` for an
+empty result.
+
+```ts sample
+import { Connection, Model, ModelBase, Primary, CreatedAt } from '@spinajs/orm';
+import { DateTime } from 'luxon';
+
+@Connection('default')
+@Model('orders')
+export class Order extends ModelBase<Order> {
+  @Primary()
+  public Id: number;
+
+  public Status: string;
+
+  public Total: number;
+
+  @CreatedAt()
+  public CreatedAt: DateTime;
+}
+
+export async function aggregates() {
+  const latest = await Order.newest();
+  const firstEver = await Order.oldest();
+
+  const openCount = await Order.count(function () {
+    this.where('Status', 'open');
+  });
+
+  const firstBigOne = await Order.first(function () {
+    this.where('Total', '>', 1000);
+  });
+
+  return { latest, firstEver, openCount, firstBigOne };
+}
+```
+
+### `exists(pk)` → `Promise<boolean>`
+
+Selects only the key columns and reports whether a row came back.
+
+### `whereExists(relationOrQuery, callback)` / `whereNotExists(relationOrQuery, callback)`
+
+Correlated `EXISTS` / `NOT EXISTS`. Takes either a relation **name** or a ready sub-query.
+Covered in [06-query-builder.md](06-query-builder.md).
+
+## Writing
+
+### `insert(data, behaviour?)` → `Promise`
+
+Accepts a model instance, a plain object, or an array of either.
+
+```ts sample
+import { Connection, Model, ModelBase, Primary, InsertBehaviour } from '@spinajs/orm';
+
+@Connection('default')
+@Model('users')
+export class User extends ModelBase<User> {
+  @Primary()
+  public Id: number;
+
+  public Email: string;
+
+  public Name: string;
+}
+
+export async function writing() {
+  await User.insert({ Email: 'a@example.com', Name: 'A' });
+
+  // Bulk. An empty array short-circuits and issues no statement.
+  await User.insert([
+    { Email: 'b@example.com', Name: 'B' },
+    { Email: 'c@example.com', Name: 'C' },
+  ]);
+
+  // Upsert behaviours — single rows only.
+  await User.insert({ Email: 'a@example.com', Name: 'A2' }, InsertBehaviour.InsertOrUpdate);
+  await User.insert({ Email: 'a@example.com', Name: 'A3' }, InsertBehaviour.InsertOrIgnore);
+  await User.insert({ Email: 'a@example.com', Name: 'A4' }, InsertBehaviour.InsertOrReplace);
+}
+```
+
+`InsertBehaviour`:
+
+| Value | Effect |
+| --- | --- |
+| `None` (default) | Plain `INSERT`. |
+| `InsertOrIgnore` | Skip the row when the key already exists. |
+| `InsertOrUpdate` | `ON DUPLICATE KEY UPDATE` over every non-primary-key column. |
+| `InsertOrReplace` | Replace the existing row. |
+
+Passing anything other than `None` **with an array throws** — the behaviours are mixed-mode
+inserts whose row-to-key mapping cannot be reconstructed.
+
+#### Reading generated keys back
+
+This is the subtlest part of the static insert path. After the statement runs, the ORM tries in
+this order:
+
+1. **`RETURNING`.** When the dialect supports it (`supportedFeatures().insertReturning`) and the
+   model has an `auto` key, the insert asks for the key columns back and assigns them
+   positionally. Authoritative.
+2. **Single row, auto key.** One row means one identity value — safe to assign.
+3. **Contiguous batch backfill.** Only when the dialect declares
+   `insertIdIsFirstOfBatch` (MySQL/InnoDB does; MSSQL and SQLite do not), the key is a single
+   `auto` column, the behaviour is `None`, the server reported `RowsAffected === rows.length`,
+   and *no* input row carried an explicit key. Then `LastInsertId + index` is assigned.
+4. **Otherwise nothing is assigned.** A dialect whose insert id names the last row, a batch
+   mixing supplied and generated keys, or a statement that did not insert one row per input row
+   cannot be mapped positionally. Re-select, or insert one at a time.
+
+### `create(data)` → `Promise`
+
+Constructs an instance, `insert()`s it, and resolves the instance — so you get the generated key.
+
+### `getOrCreate(pk, data)` → `Promise`
+
+Looks up by primary key (when `pk` is not `null`) **and** by every `Unique` column present in
+`data`. Inserts and returns a new instance when nothing matched.
+
+### `getOrNew(data?)` → `Promise`
+
+Same search, but does **not** insert. The returned new instance has any auto-increment key
+column stripped from the hydration data, so the database still assigns it.
+
+```ts sample
+import { Connection, Model, ModelBase, Primary } from '@spinajs/orm';
+
+@Connection('default')
+@Model('tags')
+export class Tag extends ModelBase<Tag> {
+  @Primary()
+  public Id: number;
+
+  /** Reflected as UNIQUE — getOrCreate/getOrNew search on it. */
+  public Slug: string;
+
+  public Label: string;
+}
+
+export async function upserts() {
+  const persisted = await Tag.getOrCreate(null, { Slug: 'news', Label: 'News' });
+
+  const draft = await Tag.getOrNew({ Slug: 'sport', Label: 'Sport' });
+  draft.Label = 'Sports';
+  await draft.insert();
+
+  return { persisted, draft };
+}
+```
+
+### `update(data)`
+
+A bare `UpdateQueryBuilder` carrying the patch — **add your own `where`**. Passing a `ModelBase`
+throws; use the instance's own `update()` for that.
+
+```ts sample
+import { Connection, Model, ModelBase, Primary } from '@spinajs/orm';
+
+@Connection('default')
+@Model('orders')
+export class Order extends ModelBase<Order> {
+  @Primary()
+  public Id: number;
+
+  public Status: string;
+}
+
+export async function bulkUpdate() {
+  await Order.update({ Status: 'archived' }).where('Status', 'closed');
+}
+```
+
+### `destroy(pks)`
+
+Deletes by primary key, or — when the model has `@SoftDelete` — updates the delete column
+instead. Accepts a scalar, a tuple, or an array of either.
+
+It **throws on `undefined`/`null` and on an empty array**. An unbounded `DELETE` is not
+something you get by forgetting an argument; use `truncate()` when you mean the whole table.
+
+```ts sample
+import { Connection, Model, ModelBase, Primary } from '@spinajs/orm';
+
+@Connection('default')
+@Model('sessions')
+export class Session extends ModelBase<Session> {
+  @Primary()
+  public Id: number;
+
+  public Token: string;
+}
+
+export async function deleting() {
+  await Session.destroy(42);
+  await Session.destroy([1, 2, 3]);
+  await Session.truncate();
+}
+```
+
+### `truncate()`
+
+Empties the table. Returns a `TruncateTableQueryBuilder`.
+
+### `transaction(callback)` → `Promise`
+
+Runs the callback inside a transaction on this model's connection, resolving with whatever the
+callback returned. Nesting takes a savepoint — see [09-transactions.md](09-transactions.md).
+
+```ts sample
+import { Connection, Model, ModelBase, Primary } from '@spinajs/orm';
+
+@Connection('default')
+@Model('accounts')
+export class Account extends ModelBase<Account> {
+  @Primary()
+  public Id: number;
+
+  public Balance: number;
+}
+
+export async function move(fromId: number, toId: number, amount: number) {
+  return await Account.transaction(async () => {
+    const from = await Account.getOrFail(fromId);
+    const to = await Account.getOrFail(toId);
+
+    from.Balance -= amount;
+    to.Balance += amount;
+
+    await from.update();
+    await to.update();
+
+    return to.Balance;
+  });
+}
+```
+
+### `populate(relation, owner)`
+
+Builds a query that loads one relation for one owner, without going through an instance. The
+owner may be a model or a bare key value. See [07-relations.md](07-relations.md).
+
+Not every relation type is supported: `Query` and `Virtual` relations throw
+`Query population for relation type ... is not supported yet`.
+
+## Ordering fallback
+
+`get`, `getOrFail`, `first`, `last`, `getOrCreate` and `getOrNew` apply a deterministic ordering
+before taking a row, so "first" means something stable. `_prepareOrderBy` picks, in order: the
+primary key, then unique columns, then the `@CreatedAt` column.
+
+## The functional helpers
+
+`fp.ts` exports small composable wrappers for pipeline-style code. They reject with
+`ErrorCode(E_ORM_CODES.E_NO_ROWS_AFFECTED)` when a write reports no rows affected.
+
+```ts sample
+import { Connection, Model, ModelBase, Primary, _get_entity, _update, _insert, _delete } from '@spinajs/orm';
+
+@Connection('default')
+@Model('users')
+export class User extends ModelBase<User> {
+  @Primary()
+  public Id: number;
+
+  public Name: string;
+}
+
+export async function functional() {
+  // `_get_entity` returns a THUNK — call it to run the fetch. That is what makes it
+  // composable: the pipeline is assembled first and executed later.
+  const fetchUser = _get_entity(1, User);
+
+  // Fetch by id (or pass an instance, optionally refreshed with `fresh = true`), then update.
+  const updated = await fetchUser().then(_update<User>({ Name: 'Renamed' }));
+
+  const created = await _insert<User>()(new User({ Name: 'Fresh' }));
+  const removed = await _delete<User>()(updated);
+
+  return { updated, created, removed };
+}
+```
+
+Note the asymmetry: `_update` and `_insertOrUpdate` resolve the model even when nothing was
+written, because a clean model short-circuits to `RowsAffected: 0` and that is a successful
+no-op. `_insert` and `_delete` treat `RowsAffected <= 0` as a failure. `uuid` and `assigned`
+keys report `LastInsertId: 0` on a *successful* insert, so only `RowsAffected` is meaningful
+there.
+
+## Statics added by other packages
+
+`@spinajs/orm-http` installs `filter()`, `filterColumns()` and `filterSchema()` onto every model
+during its own bootstrap. See [orm-http's docs](../../orm-http/docs/03-filtering.md).

--- a/packages/orm/docs/05-instance-api.md
+++ b/packages/orm/docs/05-instance-api.md
@@ -1,0 +1,419 @@
+# Instance API
+
+Everything on a `ModelBase` instance: construction, dirty tracking, the four write paths, and
+serialization.
+
+## Construction
+
+```ts sample
+import { Connection, Model, ModelBase, Primary } from '@spinajs/orm';
+
+@Connection('default')
+@Model('users')
+export class User extends ModelBase<User> {
+  @Primary()
+  public Id: number;
+
+  public Email: string;
+
+  public Name: string;
+}
+
+export function construct() {
+  const blank = new User();
+  const filled = new User({ Email: 'a@example.com', Name: 'A' });
+
+  return { blank, filled };
+}
+```
+
+The constructor does three things:
+
+1. `setDefaults()` — assigns each column its reflected `DefaultValue`, generates `@Uuid` columns
+   and `uuid`-strategy primary keys, stamps `@CreatedAt`, and instantiates a relation object for
+   every declared relation.
+2. Hydrates the argument, when given.
+3. **Returns a `Proxy`.** Writing a property that is a known column sets `IsDirty` and records
+   the name. This is why `new User()` returns something that is not quite the raw instance.
+
+The generic parameter (`ModelBase<User>`) types the constructor's `data` argument. It is
+optional; `extends ModelBase` works, but you lose that typing.
+
+## Identity
+
+### `ModelDescriptor`
+
+The model's descriptor, read fresh from class metadata each access.
+
+### `Container`
+
+The DI container of this model's connection — the driver owns a child container holding the
+dialect's statements, compilers and converters. Throws if the connection is unknown.
+
+### `PrimaryKeyName: string[]`
+
+Key column names.
+
+### `PrimaryKeyValue`
+
+A **scalar** for a single-column key, a **tuple in key order** for a composite one.
+
+Assigning it also cascades into loaded relations: a `One` relation's foreign key is rewritten,
+and every member of a `Many` relation gets the new value. Cascading is **skipped for composite
+keys** — a relation names one column and cannot carry a tuple.
+
+```ts sample
+import { Connection, Model, ModelBase, Primary } from '@spinajs/orm';
+
+@Connection('default')
+@Model('composite_table')
+export class TenantRecord extends ModelBase {
+  @Primary()
+  public TenantId: number;
+
+  @Primary()
+  public Code: string;
+}
+
+export function keys() {
+  const record = new TenantRecord();
+
+  record.PrimaryKeyValue = [1, 'AB'];         // tuple, in declaration order
+  record.PrimaryKeyValue = { TenantId: 1, Code: 'AB' }; // or keyed by column
+
+  return record.PrimaryKeyValue;              // [1, 'AB']
+}
+```
+
+`valueOf()` returns `PrimaryKeyValue`, so a model coerces to its key in numeric contexts.
+
+## Dirty tracking and snapshots
+
+Two independent mechanisms, and the difference matters.
+
+**`IsDirty` / `__dirty_props__`** — the proxy records a property as dirty on *any* write,
+including one that puts the original value straight back.
+
+**The snapshot** — a baseline captured when the instance was hydrated from a database row.
+`changedColumns()` diffs against it, so a column written `A → B → A` reports no change.
+
+`update()` and `save()` both build their payload from the **snapshot diff**, not the dirty list,
+because the diff is the more precise answer.
+
+| Member | Meaning |
+| --- | --- |
+| `Snapshot` | The baseline, or `null` for a model never loaded from the database. Read-only. |
+| `takeSnapshot()` | Capture current column values as the baseline. Values are **copied**, never aliased. |
+| `snapshotRelation(name)` | Record the current member primary keys of one relation. No-op without a snapshot. |
+| `clearSnapshot()` | Discard the baseline. The model is then treated as brand new — an INSERT. |
+| `changedColumns()` | Columns differing from the baseline. With no baseline, **every** column. |
+| `markDirty(prop)` | Record a column as changed and set `IsDirty`. |
+
+`Snapshot === null` — not the absence of a primary key — is what classifies a model as an
+INSERT. That distinction exists because `setDefaults()` pre-fills `@Uuid` keys at construction,
+so a brand-new model can perfectly well have a key already.
+
+`markDirty` is the supported way for a relation object to report that it rewrote one of the
+owner's foreign keys. It matters because `SingleRelation.attach()` stores the new target on the
+relation wrapper but never writes the column on the model — the value is materialised later by
+`StandardModelToSqlConverter`. Without `markDirty`, `changedColumns()` would compare the column
+against its snapshot, find it untouched, and emit nothing.
+
+```ts sample
+import { Connection, Model, ModelBase, Primary } from '@spinajs/orm';
+
+@Connection('default')
+@Model('users')
+export class User extends ModelBase<User> {
+  @Primary()
+  public Id: number;
+
+  public Name: string;
+}
+
+export async function tracking() {
+  const user = await User.getOrFail(1);   // hydrated => has a snapshot
+
+  const originalName = user.Name;
+  user.Name = 'Changed';
+  user.Name = originalName;
+
+  user.IsDirty;            // true  — the proxy saw two writes
+  user.changedColumns();   // []    — net change is nothing
+
+  await user.update();     // issues no statement
+}
+```
+
+## Hydration and attachment
+
+### `hydrate(data)`
+
+Fills the model by running every registered `ModelHydrator`. See
+[11-converters-and-hydration.md](11-converters-and-hydration.md).
+
+### `attach(model)`
+
+Places a related model into whichever relation targets its class, and sets the foreign key.
+
+Matching is by **constructor identity**, not class name — name matching pushed a row into every
+relation whose target happened to share a name, and broke under minification.
+
+For a `Many` relation it also sets the child's back-reference when the child declares one. For
+`ManyToMany` it does not: that link lives in the junction table, not on the target row.
+
+```ts sample
+import { Connection, Model, ModelBase, Primary, BelongsTo, HasMany, Relation, SingleRelation } from '@spinajs/orm';
+
+@Connection('default')
+@Model('order_items')
+export class OrderItem extends ModelBase<OrderItem> {
+  @Primary()
+  public Id: number;
+
+  public order_id: number;
+
+  public Sku: string;
+
+  @BelongsTo('Order', 'order_id', 'Id')
+  public Order: SingleRelation<Order>;
+}
+
+@Connection('default')
+@Model('orders')
+export class Order extends ModelBase<Order> {
+  @Primary()
+  public Id: number;
+
+  @HasMany(OrderItem, { foreignKey: 'order_id', primaryKey: 'Id' })
+  public Items: Relation<OrderItem, Order>;
+}
+
+export async function attaching() {
+  const order = await Order.getOrFail(1);
+
+  // Pushes onto Items and sets the child's back-reference.
+  order.attach(new OrderItem({ Sku: 'ABC-1' }));
+
+  await order.save();
+}
+```
+
+## Writing
+
+### `insert(behaviour?)` → `Promise<IUpdateResult>`
+
+Inserts this instance.
+
+Client-side keys are generated and `assigned` keys asserted **before** any SQL is built, so a
+missing `assigned` key fails with a clear message rather than a `NOT NULL` violation.
+
+The generated key comes back via `RETURNING` when the dialect supports it and the key strategy
+is `auto`; otherwise from the reported insert id — and only when the key is actually missing, so
+a `uuid` or `assigned` key you supplied is never overwritten.
+
+`RETURNING` is deliberately *not* requested for `InsertBehaviour.InsertOrUpdate`.
+
+### `update(data?)` → `Promise<IUpdateResult>`
+
+Writes only the columns that differ from the snapshot, plus any foreign key a relation reported
+through `markDirty`. Primary key columns are excluded from the `SET` list.
+
+When nothing changed it clears `IsDirty` and returns `{ RowsAffected: 0, LastInsertId: 0 }`
+without touching the database.
+
+When something *is* written and the model has `@UpdatedAt`, the column is stamped and added to
+the change set. Afterwards `IsDirty` is cleared and a fresh snapshot is taken.
+
+### `insertOrUpdate()` → `Promise<IUpdateResult>`
+
+`update()` when `PrimaryKeyValue` is truthy, `insert()` otherwise. Note this uses plain
+truthiness, so it does not do the careful tuple check `destroy()` does.
+
+### `save(options?)` → `Promise<ISaveResult>`
+
+Persists this model **and everything reachable from it** in one transaction. This is the unit of
+work; it has its own page — [08-unit-of-work.md](08-unit-of-work.md).
+
+### `destroy()` → `Promise<IUpdateResult>`
+
+Deletes the row, or stamps the `@SoftDelete` column. Returns early without issuing anything when
+any part of the primary key is unset — checked per element, because a composite key is a tuple
+and a tuple is always truthy.
+
+### `archive()` → `Promise<IUpdateResult>`
+
+Stamps the `@Archived` column and writes the whole model. Throws when the model has no archive
+column.
+
+```ts sample
+import { Connection, Model, ModelBase, Primary, InsertBehaviour } from '@spinajs/orm';
+
+@Connection('default')
+@Model('users')
+export class User extends ModelBase<User> {
+  @Primary()
+  public Id: number;
+
+  public Email: string;
+
+  public Name: string;
+}
+
+export async function writes() {
+  const user = new User({ Email: 'a@example.com', Name: 'A' });
+  await user.insert();
+  user.Id;                              // assigned from RETURNING or the insert id
+
+  user.Name = 'A renamed';
+  await user.update();                  // UPDATE users SET Name = ? WHERE Id = ?
+
+  await user.insertOrUpdate();          // has a key => update
+  await user.destroy();
+
+  const upserted = new User({ Email: 'a@example.com', Name: 'A again' });
+  await upserted.insert(InsertBehaviour.InsertOrUpdate);
+}
+```
+
+## Refreshing
+
+### `fresh()` → `Promise<this>`
+
+Re-reads the row and resolves a **new** instance. Filters on the primary key, falling back to
+unique columns when the model has no key. Throws when the row is gone (`firstOrFail`).
+
+### `refresh()` → `Promise<void>`
+
+Re-reads the row and copies every column onto **this** instance, then clears `IsDirty`.
+
+Note it copies columns only, and does not take a new snapshot — so the baseline still reflects
+whatever was there before. Use `save({ reload: true })` when you need a properly rebased diff.
+
+```ts sample
+import { Connection, Model, ModelBase, Primary } from '@spinajs/orm';
+
+@Connection('default')
+@Model('users')
+export class User extends ModelBase<User> {
+  @Primary()
+  public Id: number;
+
+  public Name: string;
+}
+
+export async function refreshing() {
+  const user = await User.getOrFail(1);
+
+  const copy = await user.fresh();   // new instance
+  await user.refresh();              // same instance, columns overwritten
+
+  return { user, copy };
+}
+```
+
+## Serialization
+
+### `dehydrate(options?)`
+
+Plain object of the model's **columns only**. Skips columns in `options.omit`, skips the
+instance's `_hidden` list, and skips foreign keys managed by a relation unless they are also
+primary keys. Runs each column's converter `toDB`.
+
+It **throws** `Field X cannot be null` for a non-nullable, non-primary-key column holding
+`null`, `undefined` or `''` — pass `ignoreNullable: true` to allow it.
+
+### `dehydrateWithRelations(options?)`
+
+Same, plus relations recursed. A `One` relation with no loaded value falls back to emitting the
+raw foreign key. A `Many` relation with no members emits `[]`.
+
+Note that `omit` is **not** propagated into nested relations — the recursive calls pass
+`omit: []` deliberately, so an omission applies to the top level only.
+
+### `toJSON()`
+
+`dehydrate()` with no options. This is what `JSON.stringify(model)` calls.
+
+### `toSql(onlyDirty?)`
+
+The database-shaped payload, via `ModelToSqlConverter`. With `onlyDirty` it is narrowed to
+`__dirty_props__` — the *dirty list*, not the snapshot diff.
+
+`IDehydrateOptions`:
+
+| Option | Meaning |
+| --- | --- |
+| `omit` | Field names to leave out. |
+| `skipNull` | Drop `null` values. |
+| `skipUndefined` | Drop `undefined` values. |
+| `skipEmptyArray` | Drop empty arrays. |
+| `ignoreNullable` | Do not throw on an unset non-nullable column. |
+| `dateTimeFormat` | `'iso' \| 'sql' \| 'unix'` — passed through to the datetime converter. |
+
+```ts sample
+import { Connection, Model, ModelBase, Primary, Ignore } from '@spinajs/orm';
+
+@Connection('default')
+@Model('users')
+export class User extends ModelBase<User> {
+  @Primary()
+  public Id: number;
+
+  public Email: string;
+
+  @Ignore()
+  public Password: string;
+
+  /** Never leaves the process. */
+  protected _hidden: string[] = ['Password'];
+}
+
+export async function serializing() {
+  const user = await User.getOrFail(1);
+
+  const plain = user.dehydrate();
+  const asJson = JSON.stringify(user);
+  const partial = user.dehydrate({ omit: ['Email'], skipNull: true });
+  const deep = user.dehydrateWithRelations({ dateTimeFormat: 'iso' });
+
+  return { plain, asJson, partial, deep };
+}
+```
+
+## Relation traversal
+
+### `getFlattenRelationModels(recursive?)`
+
+Every model held in this model's relations as a flat array. With `recursive: true` it walks the
+whole graph.
+
+```ts sample
+import { Connection, Model, ModelBase, Primary, HasMany, Relation } from '@spinajs/orm';
+
+@Connection('default')
+@Model('nodes')
+export class Node extends ModelBase<Node> {
+  @Primary()
+  public Id: number;
+
+  public parent_id: number;
+
+  @HasMany('Node', { foreignKey: 'parent_id', primaryKey: 'Id' })
+  public Children: Relation<Node, Node>;
+}
+
+export async function walk() {
+  const root = await Node.getOrFail(1);
+  await root.Children.populate();
+
+  const direct = root.getFlattenRelationModels();
+  const everything = root.getFlattenRelationModels(true);
+
+  return { direct, everything };
+}
+```
+
+## `driver()`
+
+The `OrmDriver` for this model's connection.

--- a/packages/orm/docs/06-query-builder.md
+++ b/packages/orm/docs/06-query-builder.md
@@ -1,0 +1,586 @@
+# Query builder
+
+Four builders sit on top of a shared set of mixins: `SelectQueryBuilder`, `InsertQueryBuilder`,
+`UpdateQueryBuilder` and `DeleteQueryBuilder`. The schema builders are covered separately in
+[10-schema-and-migrations.md](10-schema-and-migrations.md).
+
+## Execution
+
+A builder is `PromiseLike`. `then()` delegates to `execute()`, and **execution is memoized** —
+a builder runs at most once, and awaiting it again resolves with the same result. Call `clone()`
+when you genuinely want a second round-trip.
+
+```ts sample
+import { Connection, Model, ModelBase, Primary } from '@spinajs/orm';
+
+@Connection('default')
+@Model('users')
+export class User extends ModelBase<User> {
+  @Primary()
+  public Id: number;
+
+  public Name: string;
+}
+
+export async function execution() {
+  const query = User.where('Name', 'like', 'A%');
+
+  const first = await query;
+  const same = await query;         // memoized — no second round-trip
+  const again = await query.clone(); // a real second query
+
+  // Inspect the SQL without running it. Idempotent.
+  const { expression, bindings } = User.select().toDB() as { expression: string | null; bindings: unknown[] | null };
+
+  return { first, same, again, expression, bindings };
+}
+```
+
+`toDB()` compiles to `{ expression, bindings }` (or an array of them for multi-statement schema
+builders). It never executes.
+
+## Building a builder without a model
+
+`OrmDriver` exposes raw builders that bypass the model layer entirely.
+
+```ts sample
+import { DI } from '@spinajs/di';
+import { OrmDriver } from '@spinajs/orm';
+
+export async function raw() {
+  const driver = DI.resolve<OrmDriver>('OrmConnection', ['default'])!;
+
+  const rows = await driver.select().from('users').where('Id', '>', 10);
+  await driver.insert().into('audit').values({ Message: 'hello' });
+  await driver.update().in('users').update({ Name: 'x' }).where('Id', 1);
+  await driver.del().from('users').where('Id', 1);
+
+  return rows;
+}
+```
+
+## Selecting columns
+
+| Method | Effect |
+| --- | --- |
+| `select(column, alias?)` | Add one column. |
+| `select(rawQuery)` | Add a raw expression. |
+| `select(Map<column, alias>)` | Add several with aliases. |
+| `columns(names[])` | **Replace** the column list. |
+| `clearColumns()` | Drop every selected column. |
+| `getColumns()` | The current column statements. |
+| `distinct()` | `SELECT DISTINCT`. |
+
+When the builder has a model, `select('col')` validates the name against the descriptor and
+throws `Column X does not exist on model Y` for an unknown one. Virtual columns are excluded
+from the lookup. `select('*')` is special-cased and always allowed.
+
+`distinct()` throws `Cannot force DISTINCT on unknown column` when no columns are selected or
+the first one is the wildcard.
+
+```ts sample
+import { Connection, Model, ModelBase, Primary, RawQuery } from '@spinajs/orm';
+
+@Connection('default')
+@Model('users')
+export class User extends ModelBase<User> {
+  @Primary()
+  public Id: number;
+
+  public Name: string;
+
+  public Email: string;
+}
+
+export async function columns() {
+  const some = await User.query().select('Id').select('Name', 'DisplayName');
+
+  const aliased = await User.query().select(new Map([['Email', 'Address']]));
+
+  const computed = await User.query()
+    .select('Id')
+    .select(RawQuery.create('UPPER(Name) as Shouted'));
+
+  const unique = await User.query().select('Name').distinct();
+
+  return { some, aliased, computed, unique };
+}
+```
+
+## The where family
+
+Every method exists in `where` / `andWhere` / `orWhere` form. The boolean connector set by
+`orWhere` / `andWhere` applies to the **next** pushed statement only and then resets to `AND`,
+so `where(a).where(b).orWhere(c).where(d)` compiles to `a AND b OR c AND d` rather than
+rewriting the whole clause.
+
+| Method | Produces |
+| --- | --- |
+| `where(column, value)` | `column = value` |
+| `where(column, operator, value)` | `column <op> value` |
+| `where(object)` | `AND` of `key = value`, via `whereObject` |
+| `where(callback)` | A parenthesised nested group |
+| `where(rawQuery)` | Raw SQL with bindings |
+| `where(true \| false)` | `TRUE` / `FALSE` |
+| `where(wrap)` | A wrapped column, e.g. date truncation |
+| `whereObject(obj)` | Same as `where(object)` |
+| `whereNull(c)` / `whereNotNull(c)` | `IS NULL` / `IS NOT NULL` |
+| `whereNot(c, v)` | `c != v` |
+| `whereIn(c, [])` / `whereNotIn(c, [])` | `IN` / `NOT IN` |
+| `whereBetween(c, [a, b])` / `whereNotBetween` | `BETWEEN` |
+| `whereInSet(c, [])` / `whereNotInSet(c, [])` | Set-membership (MySQL `SET` columns) |
+| `whereExist(q, cb?)` / `whereNotExists(q, cb?)` | `EXISTS` / `NOT EXISTS` |
+| `when(condition, cb, elseCb?)` | Conditional clause building |
+| `clearWhere()` | Drop every condition |
+
+Valid operators (`Op`): `<` `>` `!=` `<=>` `>=` `<=` `<>` `like` `=` `rlike` `regexp`. An
+invalid one throws `operator X is invalid`.
+
+### Null handling
+
+`where(c, null)` becomes `IS NULL`. With an explicit operator, `=` gives `IS NULL` and `!=` /
+`<>` give `IS NOT NULL`; any other operator with `null` throws.
+
+### Empty arrays
+
+`whereIn(c, [])` compiles to `FALSE`, matching SQL's `IN ()` semantics. It deliberately does not
+emit "no condition", which would silently match every row. `whereObject` routes array values
+through `whereIn`, so the same rule applies there.
+
+`undefined` and `NaN` values throw `InvalidArgument`.
+
+```ts sample
+import { Connection, Model, ModelBase, Primary, RawQuery } from '@spinajs/orm';
+
+@Connection('default')
+@Model('orders')
+export class Order extends ModelBase<Order> {
+  @Primary()
+  public Id: number;
+
+  public Status: string;
+
+  public Total: number;
+
+  public Note: string;
+}
+
+export async function filtering(onlyOpen: boolean) {
+  const grouped = await Order.query()
+    .select('*')
+    .where('Total', '>', 100)
+    .andWhere(function () {
+      this.where('Status', 'open').orWhere('Status', 'pending');
+    });
+
+  const nulls = await Order.query().select('*').whereNull('Note');
+
+  const sets = await Order.query().select('*').whereIn('Status', ['open', 'closed']);
+
+  const ranges = await Order.query().select('*').whereBetween('Total', [10, 100]);
+
+  const conditional = await Order.query()
+    .select('*')
+    .when(onlyOpen, function () {
+      this.where('Status', 'open');
+    });
+
+  const rawly = await Order.query()
+    .select('*')
+    .where(RawQuery.create('Total > (SELECT AVG(Total) FROM orders)'));
+
+  return { grouped, nulls, sets, ranges, conditional, rawly };
+}
+```
+
+### Searching by relation
+
+Two conveniences, both handled inside `where`:
+
+**A dotted column populates the relation and applies the condition there.**
+`where('Owner.Name', 'Ada')` calls `populate('Owner', function () { this.where('Name', 'Ada') })`.
+
+**A bare relation name resolves to its foreign key.** `where('Owner', 3)` becomes
+`where('owner_id', 3)`.
+
+The same dotted-path handling exists on `order`, `orderBy` and `orderByDescending`.
+
+### EXISTS on a relation
+
+`whereExist` / `whereNotExists` take either a ready sub-query or a **relation name**. Given a
+name, the builder resolves an `ExistsRelationHandler` registered for that relation type and lets
+it either mutate the builder or return a correlated sub-query to wrap.
+
+```ts sample
+import { Connection, Model, ModelBase, Primary, HasMany, Relation } from '@spinajs/orm';
+
+@Connection('default')
+@Model('order_items')
+export class OrderItem extends ModelBase<OrderItem> {
+  @Primary()
+  public Id: number;
+
+  public order_id: number;
+
+  public Sku: string;
+}
+
+@Connection('default')
+@Model('orders')
+export class Order extends ModelBase<Order> {
+  @Primary()
+  public Id: number;
+
+  @HasMany(OrderItem, { foreignKey: 'order_id', primaryKey: 'Id' })
+  public Items: Relation<OrderItem, Order>;
+}
+
+export async function existence() {
+  const withItems = await Order.whereExists('Items', function () {
+    this.where('Sku', 'like', 'ABC-%');
+  });
+
+  const empty = await Order.whereNotExists('Items', function () {});
+
+  return { withItems, empty };
+}
+```
+
+## Ordering, limits and single rows
+
+| Method | Effect |
+| --- | --- |
+| `order(column, direction)` | Add a sort. |
+| `orderBy(column)` / `orderByDescending(column)` | Ascending / descending shorthand. |
+| `getSort()` | The **first** sort entry, or `null`. |
+| `getSorts()` | All sort entries. |
+| `take(n)` | `LIMIT`. Rejects negatives. |
+| `skip(n)` | `OFFSET`. Rejects negatives. |
+| `takeFirst()` | `LIMIT 1` and unwrap the array. |
+| `first()` | `takeFirst()` and await — resolves `undefined` when empty. |
+| `firstOrFail()` | `first()` or throw `OrmNotFoundException`. |
+| `firstOrThrow(error)` | `first()` or throw your error. |
+| `orThrow(error)` | Throw when the whole result is empty. |
+| `getLimits()` | `{ limit, offset }`. |
+
+`firstOrThrow` and `orThrow` accept either an `Error` or a function receiving the compiled
+`ICompilerOutput`, which lets the error carry the offending SQL.
+
+```ts sample
+import { Connection, Model, ModelBase, Primary, SortOrder, ICompilerOutput } from '@spinajs/orm';
+
+@Connection('default')
+@Model('users')
+export class User extends ModelBase<User> {
+  @Primary()
+  public Id: number;
+
+  public Name: string;
+
+  public Age: number;
+}
+
+export async function ordering() {
+  const page = await User.query().select('*').orderBy('Name').take(20).skip(40);
+
+  const multi = await User.query().select('*').order('Age', SortOrder.DESC).order('Name', SortOrder.ASC);
+
+  const one = await User.query().select('*').where('Id', 1).first();
+
+  const strict = await User.query()
+    .select('*')
+    .where('Id', 999)
+    .firstOrThrow((output: ICompilerOutput) => new Error(`nothing matched: ${output.expression}`));
+
+  return { page, multi, one, strict };
+}
+```
+
+## Aggregates
+
+| Method | Effect |
+| --- | --- |
+| `count(column?, as?)` | **Clears the column list** and selects `COUNT(...)`. Defaults to `COUNT(*) as count`. |
+| `selectCount(column?, as?)` | `count()` + `takeFirst()` + `asRaw()`, resolving the number. |
+| `min` / `max` / `sum` / `avg` `(column, as?)` | Add the aggregate as a column. |
+| `groupBy(expression)` | `GROUP BY`. Takes a string or a `RawQuery`. |
+| `clearGroupBy()` | Drop grouping. |
+
+`count()` clearing the column list is easy to trip over: call it first, or lose your selections.
+
+```ts sample
+import { Connection, Model, ModelBase, Primary, RawQuery } from '@spinajs/orm';
+
+@Connection('default')
+@Model('orders')
+export class Order extends ModelBase<Order> {
+  @Primary()
+  public Id: number;
+
+  public Status: string;
+
+  public Total: number;
+}
+
+export async function aggregating() {
+  const total = await Order.query().where('Status', 'open').selectCount();
+
+  const perStatus = await Order.query()
+    .select('Status')
+    .sum('Total', 'Revenue')
+    .groupBy('Status')
+    .asRaw<Array<{ Status: string; Revenue: number }>>();
+
+  const byMonth = await Order.query()
+    .select('Status')
+    .max('Total', 'Biggest')
+    .groupBy(RawQuery.create('Status'))
+    .asRaw<Array<{ Status: string; Biggest: number }>>();
+
+  return { total, perStatus, byMonth };
+}
+```
+
+## Raw results
+
+`asRaw<T>()` skips model hydration entirely and resolves whatever the driver returned. Use it
+for aggregates and projections that do not correspond to a model.
+
+`resultExists()` executes and reports whether anything came back.
+
+`all()` is a typing convenience that just calls `execute()`.
+
+## Joins
+
+Every join method takes the same four shapes:
+
+- `join(RawQuery)` — raw
+- `join(relationName, callback?, queryCallback?)` — derive the ON clause from a relation
+- `join(ModelClass, callback?, queryCallback?)` — find the relation by target model
+- `join(IJoinStatementOptions)` — spell everything out
+
+Methods: `innerJoin`, `leftJoin`, `leftOuterJoin`, `rightJoin`, `rightOuterJoin`,
+`fullOuterJoin`, `crossJoin`, and the generic `join(method, ...)`. `clearJoins()` drops them.
+
+A relation join without a model on the builder throws `Cannot use relation join without model
+defined in builder`; a model with no relations throws too.
+
+```ts sample
+import { Connection, Model, ModelBase, Primary, BelongsTo, SingleRelation, JoinMethod, RawQuery } from '@spinajs/orm';
+
+@Connection('default')
+@Model('companies')
+export class Company extends ModelBase<Company> {
+  @Primary()
+  public Id: number;
+
+  public Name: string;
+}
+
+@Connection('default')
+@Model('users')
+export class User extends ModelBase<User> {
+  @Primary()
+  public Id: number;
+
+  public company_id: number;
+
+  public Name: string;
+
+  @BelongsTo(Company, 'company_id', 'Id')
+  public Company: SingleRelation<Company>;
+}
+
+export async function joins() {
+  const byRelationName = await User.query().select('*').leftJoin('Company');
+
+  const byModel = await User.query().select('*').innerJoin(Company);
+
+  const withCondition = await User.query()
+    .select('*')
+    .leftJoin('Company', function () {
+      this.where('Name', 'like', 'Acme%');
+    });
+
+  const explicit = await User.query().select('*').join(JoinMethod.INNER, {
+    joinTable: 'companies',
+    joinTableAlias: 'c',
+    joinTableForeignKey: 'Id',
+    sourceTablePrimaryKey: 'company_id',
+  });
+
+  const rawJoin = await User.query()
+    .select('*')
+    .innerJoin(RawQuery.create('JOIN companies c ON c.Id = users.company_id'));
+
+  return { byRelationName, byModel, withCondition, explicit, rawJoin };
+}
+```
+
+`IJoinStatementOptions` fields: `joinTable`, `joinTableAlias`, `joinTableForeignKey`,
+`joinTableDatabase`, `joinTableDriver`, `joinModel`, `sourceModel`, `sourceTableAlias`,
+`sourceTablePrimaryKey`, `sourceTableDatabase`, `method`, `query`, `callback`, `queryCallback`,
+`builder`.
+
+A join callback's `WHERE` conditions are emitted in the join's own **ON** clause, not folded into
+the main query's `WHERE` — folding them would silently turn a `LEFT JOIN` into an inner filter.
+Columns and sorts from the callback *are* merged.
+
+## Recursive CTEs
+
+`withRecursive(recursiveKeyColumn, primaryKeyColumn)` builds a `WITH RECURSIVE` common table
+expression. `clearRecursive()` removes it.
+
+```ts sample
+import { Connection, Model, ModelBase, Primary } from '@spinajs/orm';
+
+@Connection('default')
+@Model('category')
+export class Category extends ModelBase<Category> {
+  @Primary()
+  public Id: number;
+
+  public parent_id: number;
+
+  public Name: string;
+}
+
+export async function tree() {
+  // Walk from each row up through parent_id.
+  return await Category.query().select('*').withRecursive('parent_id', 'Id');
+}
+```
+
+The compiler builds the CTE's anchor and recursive members from **clones** of the owning query,
+and clears the recursive flag on them — a member that stayed marked recursive would re-enter the
+compiler and recurse until the stack blew.
+
+## Table and alias control
+
+| Method | Effect |
+| --- | --- |
+| `from(table, alias?)` / `setTable(table, alias?)` | Set the table. Empty name throws. |
+| `setAlias(alias)` | Set the alias, propagating it into existing columns, joins and conditions. |
+| `database(name)` | Set the schema / database. |
+| `Table` / `TableAlias` / `Database` | Read them back. |
+
+Passing no alias to `SelectQueryBuilder.setAlias()` generates one from the table name wrapped in
+`Options.AliasSeparator`.
+
+## Soft delete
+
+For a model with `@SoftDelete`, `createQuery` adds `DeletedAt IS NULL` to every select.
+`withDeleted()` removes exactly that statement, leaving the rest of the clause intact.
+
+## Insert builder
+
+| Method | Effect |
+| --- | --- |
+| `into(table, schema?)` | Target table. |
+| `values(obj \| obj[])` | Rows. An array derives the column list from the union of the objects' keys. |
+| `orIgnore()` | `INSERT IGNORE`. |
+| `orReplace()` | `REPLACE`. |
+| `onDuplicate(column?)` | Returns an `OnDuplicateQueryBuilder`; defaults the conflict target to the model's unique columns. |
+| `returning(columns)` | Ask the dialect to echo rows back. |
+| `forceColumn(column, value)` | Overwrite a column on **every** row, whatever the caller supplied. |
+
+`returning()` **throws `NotSupported`** on a dialect without it, rather than silently doing
+nothing — which is how the API was a no-op on MySQL and MSSQL for years.
+
+`forceColumn` exists for policies that must not be negotiable (rbac's ownership stamp).
+`values()` cannot serve, because calling it again appends a row rather than amending one.
+
+```ts sample
+import { DI } from '@spinajs/di';
+import { OrmDriver } from '@spinajs/orm';
+
+export async function inserting() {
+  const driver = DI.resolve<OrmDriver>('OrmConnection', ['default'])!;
+
+  await driver.insert().into('audit').values([
+    { Message: 'one', Level: 'info' },
+    { Message: 'two', Level: 'warn' },
+  ]);
+
+  await driver.insert().into('counters').values({ Key: 'hits', Value: 1 }).onDuplicate('Key').update(['Value']);
+}
+```
+
+## Update builder
+
+`update(value)` sets the payload; `in(table)` sets the table. Add a `where` yourself — the
+builder happily compiles an unbounded `UPDATE`.
+
+## Delete builder
+
+`DeleteQueryBuilder` mixes in the where and limit builders. Same warning: it will compile an
+unbounded `DELETE`.
+
+## Middleware
+
+Two distinct hooks, and the difference is load-bearing.
+
+### `IBuilderMiddleware` — per builder, via `.middleware()`
+
+| Hook | When |
+| --- | --- |
+| `afterQuery(data)` | Raw rows are back from the driver, before anything else. |
+| `modelCreation(row)` | Override model construction. Return `null` to fall through. |
+| `afterHydration(models)` | Models are built and hydrated. Async. |
+
+`modelCreation` is resolved in **reverse registration order**; the first non-null wins. The
+pipeline is snapshotted after the driver call — compiling the query is what registers the
+relation middlewares — and never reversed in place.
+
+This is how relations are loaded: each `OrmRelation` registers a middleware that issues the
+follow-up query in `afterHydration`.
+
+### `QueryMiddleware` — global, resolved from DI
+
+```ts sample
+import { Injectable } from '@spinajs/di';
+import { QueryMiddleware, QueryBuilder, QueryContext, InsertQueryBuilder } from '@spinajs/orm';
+
+@Injectable(QueryMiddleware)
+export class TenantScope extends QueryMiddleware {
+  /** Runs from the builder's CONSTRUCTOR — nothing the caller does has happened yet. */
+  public afterQueryCreation(query: QueryBuilder): void {
+    if (query.QueryContext === QueryContext.Select) {
+      (query as any).where('TenantId', 7);
+    }
+  }
+
+  /** Runs immediately before execution, with the query fully assembled. */
+  public beforeQueryExecution(query: QueryBuilder): void {
+    if (query instanceof InsertQueryBuilder) {
+      query.forceColumn('TenantId', 7);
+    }
+  }
+}
+```
+
+Both hooks fire for **every** builder type — select, insert, update and delete.
+
+Use `afterQueryCreation` to *add a constraint*. It is the wrong place to read or amend the
+payload, which does not exist yet — no `values()`, no `update()` has been called.
+
+Use `beforeQueryExecution` to *inspect or rewrite what is about to be written*. A value written
+at construction would be overwritten by the caller's own `values()` call.
+
+A middleware that throws from either hook aborts the query.
+
+## Scopes
+
+`QueryScope` is the base class for adding reusable, typed query methods to a model through the
+static `_queryScopes` property. The builder types intersect `T['_queryScopes']`, so scope
+methods appear on every builder derived from that model.
+
+## Cloning and merging
+
+`clone()` deep-copies columns, joins, conditions, group-by statements, limits, sorts, the CTE,
+the alias and the database, and shares relations and result middlewares by reference. A cloned
+builder has a fresh execution memo.
+
+`mergeBuilder(builder, includeStatements = true)` folds another builder's columns, CTE,
+distinct flag and sorts in. `mergeRelations` and `mergeStatements` are the finer-grained
+versions used by the relation and join machinery.

--- a/packages/orm/docs/07-relations.md
+++ b/packages/orm/docs/07-relations.md
@@ -1,0 +1,629 @@
+# Relations
+
+Five relation types, declared by decorator and materialised at runtime as relation objects
+hanging off the model instance.
+
+| Decorator | `RelationType` | Runtime object | Shape |
+| --- | --- | --- | --- |
+| `@BelongsTo` / `@ForwardBelongsTo` | `One` | `SingleRelation` | This row points at one other row |
+| `@HasMany` | `Many` | `OneToManyRelationList` | Other rows point at this one |
+| `@HasManyToMany` | `ManyToMany` | `ManyToManyRelationList` | Linked through a junction table |
+| `@Query` | `Query` | `ManyQueryRelationList` | Populated by a custom query |
+| `@Virtual` | `Virtual` | your own `Relation` subclass | Populated however you like |
+
+## `@BelongsTo(target, foreignKey?, primaryKey?)`
+
+The owning side of a one-to-one / many-to-one. The **foreign key lives on this model**.
+
+- `foreignKey` defaults to the lowercased property name plus `_id` — property `Owner` → `owner_id`.
+- `primaryKey` defaults to the **target** model's primary key.
+
+```ts sample
+import { Connection, Model, ModelBase, Primary, BelongsTo, SingleRelation } from '@spinajs/orm';
+
+@Connection('default')
+@Model('companies')
+export class Company extends ModelBase<Company> {
+  @Primary()
+  public Id: number;
+
+  public Name: string;
+}
+
+@Connection('default')
+@Model('users')
+export class User extends ModelBase<User> {
+  @Primary()
+  public Id: number;
+
+  public company_id: number;
+
+  /** Defaults: foreign key `company_id`, target key `Id`. */
+  @BelongsTo(Company)
+  public Company: SingleRelation<Company>;
+
+  /** Explicit — joins users.company_code to companies.Code. */
+  @BelongsTo(Company, 'company_code', 'Code')
+  public CompanyByCode: SingleRelation<Company>;
+}
+```
+
+### Naming the target as a string
+
+Passing a model **name** instead of a class breaks import cycles. The target is resolved by
+`Orm.resolve()`'s `wireRelations()` step, and the default primary key is read lazily through a
+property accessor.
+
+In a real project `Client` and `Order` live in separate files that import each other. The file
+that would close the cycle uses `import type`, which erases at compile time, and names its
+relation target as a string so nothing is dereferenced at decoration time:
+
+```ts
+// order.ts
+import { Connection, Model, ModelBase, Primary, BelongsTo, SingleRelation } from '@spinajs/orm';
+// Type-only: a VALUE import back to Client would close the cycle and throw
+// `Cannot access 'Client' before initialization` while the decorator runs.
+import type { Client } from './client.js';
+
+@Connection('default')
+@Model('orders')
+export class Order extends ModelBase<Order> {
+  @Primary()
+  public Id: number;
+
+  public client_id: number;
+
+  @BelongsTo('Client', 'client_id', 'Id')
+  public Client: SingleRelation<Client>;
+}
+```
+
+```ts sample
+// client.ts — imports order.ts as a value, which is fine: only one side may do so.
+import { Connection, Model, ModelBase, Primary, BelongsTo, HasMany, Relation, SingleRelation } from '@spinajs/orm';
+
+@Connection('default')
+@Model('orders')
+export class Order extends ModelBase<Order> {
+  @Primary()
+  public Id: number;
+
+  public client_id: number;
+
+  @BelongsTo('Client', 'client_id', 'Id')
+  public Client: SingleRelation<Client>;
+}
+
+@Connection('default')
+@Model('clients')
+export class Client extends ModelBase<Client> {
+  @Primary()
+  public Id: number;
+
+  public Name: string;
+
+  @HasMany('Order', { foreignKey: 'client_id', primaryKey: 'Id' })
+  public Orders: Relation<Order, Client>;
+}
+```
+
+Both `'Client'` and `'Order'` are resolved to real classes by `Orm.resolve()`'s `wireRelations()`
+step. A name that matches no registered model throws
+`type X not found for relation R in model M`.
+
+### `@ForwardBelongsTo(forwardRef(() => Target), foreignKey?, primaryKey?)`
+
+The other cycle-breaker: a lazily-evaluated class reference.
+
+```ts sample
+import { Connection, Model, ModelBase, Primary, ForwardBelongsTo, forwardRef, SingleRelation } from '@spinajs/orm';
+
+@Connection('default')
+@Model('nodes')
+export class TreeNode extends ModelBase<TreeNode> {
+  @Primary()
+  public Id: number;
+
+  public parent_id: number;
+
+  @ForwardBelongsTo(forwardRef(() => TreeNode), 'parent_id', 'Id')
+  public Parent: SingleRelation<TreeNode>;
+}
+```
+
+Note `@ForwardBelongsTo` derives its default `primaryKey` from the **source** model, unlike
+`@BelongsTo` which uses the target's. Pass it explicitly when the two differ.
+
+### Composite keys
+
+A relation's `PrimaryKey` and `ForeignKey` each name exactly **one** column, because the join
+compiler emits a one-column `ON` predicate. A model with a composite primary key therefore has
+no defensible default, and the decorator throws at decoration time:
+
+```
+relation R cannot default its join column: model M has a composite primary key (A, B).
+Pass primaryKey explicitly.
+```
+
+Name the column yourself.
+
+## `@HasMany(target, options?)`
+
+The inverse side. The **foreign key lives on the target model**.
+
+| Option | Default | Meaning |
+| --- | --- | --- |
+| `foreignKey` | `<sourceModelName>_id`, lowercased | Column on the target pointing back here. |
+| `primaryKey` | This model's primary key | Column on this model the target points at. |
+| `orphan` | see [08](08-unit-of-work.md) | What `save()` does with a removed child. |
+| `type` | `OneToManyRelationList` | Custom relation class. |
+| `factory` | — | Custom relation factory function. |
+
+```ts sample
+import { Connection, Model, ModelBase, Primary, HasMany, Relation, OrphanPolicy } from '@spinajs/orm';
+
+@Connection('default')
+@Model('order_items')
+export class OrderItem extends ModelBase<OrderItem> {
+  @Primary()
+  public Id: number;
+
+  public order_id: number;
+
+  public Sku: string;
+
+  public Quantity: number;
+}
+
+@Connection('default')
+@Model('orders')
+export class Order extends ModelBase<Order> {
+  @Primary()
+  public Id: number;
+
+  public Reference: string;
+
+  @HasMany(OrderItem, {
+    foreignKey: 'order_id',
+    primaryKey: 'Id',
+    orphan: OrphanPolicy.Delete,
+  })
+  public Items: Relation<OrderItem, Order>;
+}
+```
+
+## `@HasManyToMany(junctionModel, targetModel, options?)`
+
+Many-to-many through an explicit junction model.
+
+| Option | Default | Meaning |
+| --- | --- | --- |
+| `sourceModelPKey` | This model's primary key | Column on this model. |
+| `targetModelPKey` | Target's primary key | Column on the target. |
+| `junctionModelSourcePk` | `<sourceModelName>_id` | Junction column pointing at this model. |
+| `junctionModelTargetPk` | `<targetModelName>_id` | Junction column pointing at the target. |
+| `joinMode` | — | `'LeftJoin'` or `'RightJoin'`, when the right side may be absent. |
+| `orphan` | `nullify` | Governs the **target** row. The junction row is always deleted. |
+
+```ts sample
+import { Connection, Model, ModelBase, Primary, BelongsTo, HasManyToMany, Relation, SingleRelation } from '@spinajs/orm';
+
+@Connection('default')
+@Model('locations')
+export class Location extends ModelBase<Location> {
+  @Primary()
+  public Id: number;
+
+  public Name: string;
+}
+
+@Connection('default')
+@Model('offer_location')
+export class OfferLocation extends ModelBase<OfferLocation> {
+  @Primary()
+  public Id: number;
+
+  public Offer_id: number;
+
+  public Localisation: number;
+
+  // The lazy populate path reads results back as `row[TargetModel.name].Value`, so the
+  // property MUST be named after the target model.
+  @BelongsTo(Location, 'Localisation')
+  public Location: SingleRelation<Location>;
+}
+
+@Connection('default')
+@Model('offer')
+export class Offer extends ModelBase<Offer> {
+  @Primary()
+  public Id: number;
+
+  public Name: string;
+
+  @HasManyToMany(OfferLocation, Location, {
+    sourceModelPKey: 'Id',
+    targetModelPKey: 'Id',
+    junctionModelSourcePk: 'Offer_id',
+    junctionModelTargetPk: 'Localisation',
+  })
+  public Localisations: Relation<Location, OfferLocation>;
+}
+```
+
+Two constraints worth knowing before you design the junction:
+
+- The junction model must declare a `@BelongsTo` to the target, **named after the target class**.
+  The lazy `populate()` path calls `.populate(TargetModel)` on the junction and reads results
+  back as `row[TargetModel.name].Value`.
+- A junction table carries one foreign key column per side, so it cannot address a **composite**
+  target key. `_dbDiff` throws rather than delete the wrong rows.
+
+## `@Recursive()`
+
+Applied on top of a relation, it marks it as hierarchical — populating loads the whole chain
+using a recursive CTE rather than one level.
+
+It must come **after** the relation decorator in evaluation order (so, written above it), or it
+throws `cannot set recursive on not existing relation`.
+
+```ts sample
+import { Connection, Model, ModelBase, Primary, HasMany, Recursive, Relation } from '@spinajs/orm';
+
+@Connection('default')
+@Model('category')
+export class Category extends ModelBase<Category> {
+  @Primary()
+  public Id: number;
+
+  public parent_id: number;
+
+  public Name: string;
+
+  @Recursive()
+  @HasMany('Category', { foreignKey: 'parent_id' })
+  public Children: Relation<Category, Category>;
+}
+```
+
+## `@Query(callback, mapper)`
+
+A relation whose data does not come from a single foreign key — an aggregate, a union, anything
+you can express as a query.
+
+`callback` receives the owner rows and returns a select builder. `mapper` distributes the
+results back onto each owner.
+
+```ts sample
+import { Connection, Model, ModelBase, Primary, Query, ManyQueryRelationList, ISelectQueryBuilder } from '@spinajs/orm';
+
+@Connection('default')
+@Model('audit_entries')
+export class AuditEntry extends ModelBase<AuditEntry> {
+  @Primary()
+  public Id: number;
+
+  public subject_id: number;
+
+  public Message: string;
+}
+
+@Connection('default')
+@Model('users')
+export class User extends ModelBase<User> {
+  @Primary()
+  public Id: number;
+
+  public Name: string;
+
+  @Query<User, AuditEntry>(
+    (owners) => AuditEntry.query().select('*').whereIn('subject_id', owners.map((o) => o.Id)) as ISelectQueryBuilder,
+    (owner, rows) => rows.filter((r) => r.subject_id === owner.Id),
+  )
+  public Audit: ManyQueryRelationList<AuditEntry, User>;
+}
+```
+
+A query relation is always considered populated. Every mutating method on it — `remove`, `sync`,
+`update`, `set`, `union`, `diff`, `intersection`, `populate` — throws.
+
+## `@Virtual(relationClass?)`
+
+Hands relation loading entirely to a class you write. Without an argument the class is read from
+the property's `design:type` metadata.
+
+## `@Historical(target)`
+
+Declares a `Many` relation to a history table, with the foreign key and primary key both
+defaulting to this model's primary key. Pair it with `table.trackHistory()` in the migration and
+the `HistoricalModel` interface (`__action__`, `__revision__`, `__start__`, `__end__`).
+
+## Relation objects at runtime
+
+### `SingleRelation<R, O>` — the `One` side
+
+| Member | Meaning |
+| --- | --- |
+| `Value` | The related model, `null`, or `undefined` when not loaded. |
+| `Populated` | Whether it has been loaded. |
+| `attach(obj \| null)` | Point at a model and mark the owner's foreign key dirty. No database access. |
+| `detach()` | `attach(null)`. |
+| `set(obj)` | `attach` + `owner.update()`, in one transaction. |
+| `remove()` | Delete the related row and clear the foreign key, in one transaction. |
+| `populate(callback?)` | Load it. |
+
+`populate()` queries the **target table filtered on the relation's declared join column**, not
+necessarily the target's own primary key — `@BelongsTo` takes an explicit third argument for
+exactly this case. It uses `first()` when the owner's foreign key column is nullable and
+`firstOrFail()` when it is not.
+
+```ts sample
+import { Connection, Model, ModelBase, Primary, BelongsTo, SingleRelation } from '@spinajs/orm';
+
+@Connection('default')
+@Model('companies')
+export class Company extends ModelBase<Company> {
+  @Primary()
+  public Id: number;
+
+  public Name: string;
+}
+
+@Connection('default')
+@Model('users')
+export class User extends ModelBase<User> {
+  @Primary()
+  public Id: number;
+
+  public company_id: number;
+
+  @BelongsTo(Company, 'company_id', 'Id')
+  public Company: SingleRelation<Company>;
+}
+
+export async function single() {
+  const user = await User.getOrFail(1);
+
+  await user.Company.populate();
+  const name = user.Company.Value?.Name;
+
+  // Re-point without touching the database yet.
+  const other = await Company.getOrFail(2);
+  user.Company.attach(other);
+  await user.update();
+
+  // Or attach and persist in one transaction.
+  await user.Company.set(other);
+
+  return name;
+}
+```
+
+### `Relation<R, O, Q>` — the list side
+
+Extends `Array`, so `push`, `forEach`, `length` and iteration all work.
+
+`Symbol.species` is `Array`, deliberately: methods that derive a new collection (`splice`,
+`slice`, `concat`, `filter`) build a plain array rather than trying to construct a relation
+without an owner. A slice of a relation is a list of models, not a relation.
+
+| Member | Meaning |
+| --- | --- |
+| `Populated` | Whether it has been loaded. |
+| `TargetModelDescriptor` | Descriptor of the related model. |
+| `populate(callback?)` | Load members. |
+| `set(models \| fn)` | Replace the contents. |
+| `union(models)` | Append. Shorthand for `push`. |
+| `remove(model \| models \| predicate)` | Remove from the in-memory list, returning what was removed. |
+| `empty()` / `clear()` | Drop every member. |
+| `diff(dataset, cmp?)` | Symmetric difference against a dataset. |
+| `intersection(dataset, cmp?)` | Members present in both. |
+| `update()` | Insert-or-update every dirty member, in one transaction. |
+| `sync()` | `update()`, then **delete from the database anything not in the list**. |
+
+`remove`, `set`, `union`, `empty` and `clear` are **in-memory only**. Nothing reaches the
+database until `sync()`, `update()` or `save()` runs.
+
+`diff` and `intersection` compare by primary key by default. For a composite key the comparison
+flattens the tuple into a string — passing the key array to lodash directly would be read as a
+property *path* (`obj['TenantId']['Code']`), making every row compare equal.
+
+```ts sample
+import { Connection, Model, ModelBase, Primary, HasMany, Relation } from '@spinajs/orm';
+
+@Connection('default')
+@Model('order_items')
+export class OrderItem extends ModelBase<OrderItem> {
+  @Primary()
+  public Id: number;
+
+  public order_id: number;
+
+  public Sku: string;
+}
+
+@Connection('default')
+@Model('orders')
+export class Order extends ModelBase<Order> {
+  @Primary()
+  public Id: number;
+
+  @HasMany(OrderItem, { foreignKey: 'order_id', primaryKey: 'Id' })
+  public Items: Relation<OrderItem, Order>;
+}
+
+export async function lists() {
+  const order = await Order.getOrFail(1);
+  await order.Items.populate();
+
+  order.Items.push(new OrderItem({ Sku: 'NEW-1' }));
+  order.Items.remove((item) => item.Sku === 'OLD-1');
+
+  // Writes the additions AND deletes the removed row from the database.
+  await order.Items.sync();
+
+  // Or write additions/changes only, deleting nothing.
+  await order.Items.update();
+}
+```
+
+`OneToManyRelationList._update()` assigns each member's foreign key **before** computing the
+dirty set. A child re-parented onto this owner needs its key rewritten and persisted; snapshotting
+the dirty set first would leave a previously-clean child holding its old foreign key, and a
+following `sync()` would then delete it as "not belonging" here.
+
+`ManyToManyRelationList._update()` builds a junction row per member, wires both sides through the
+junction's own relations, and inserts with `InsertOrUpdate`.
+
+## Eager loading with `populate()`
+
+`SelectQueryBuilder.populate()` is the eager path. It accepts several shapes:
+
+```ts sample
+import { Connection, Model, ModelBase, Primary, BelongsTo, HasMany, Relation, SingleRelation } from '@spinajs/orm';
+
+@Connection('default')
+@Model('companies')
+export class Company extends ModelBase<Company> {
+  @Primary()
+  public Id: number;
+
+  public Name: string;
+}
+
+@Connection('default')
+@Model('order_items')
+export class OrderItem extends ModelBase<OrderItem> {
+  @Primary()
+  public Id: number;
+
+  public order_id: number;
+
+  public Sku: string;
+}
+
+@Connection('default')
+@Model('orders')
+export class Order extends ModelBase<Order> {
+  @Primary()
+  public Id: number;
+
+  public company_id: number;
+
+  @BelongsTo(Company, 'company_id', 'Id')
+  public Company: SingleRelation<Company>;
+
+  @HasMany(OrderItem, { foreignKey: 'order_id', primaryKey: 'Id' })
+  public Items: Relation<OrderItem, Order>;
+}
+
+export async function eager() {
+  // By name.
+  const one = await Order.select().populate('Items');
+
+  // Several at once.
+  const several = await Order.select().populate(['Items', 'Company']);
+
+  // By target model class.
+  const byClass = await Order.select().populate(Company);
+
+  // With a callback constraining the relation's own query.
+  const filtered = await Order.select().populate('Items', function () {
+    this.where('Sku', 'like', 'ABC-%').orderBy('Sku');
+  });
+
+  // Nested, dotted-path form.
+  const nested = await Order.select().populate('Items.Order.Company');
+
+  return { one, several, byClass, filtered, nested };
+}
+```
+
+Relation lookup by name is case-insensitive and trimmed, for backward compatibility.
+
+### How eager loading actually runs
+
+`populate()` resolves an `IOrmRelation` for the relation type — `BelongsToRelation`,
+`OneToManyRelation`, `ManyToManyRelation`, `BelongsToRecursiveRelation`, `QueryRelation` or
+`VirtualRelation` — and calls `execute()` on it.
+
+- **`One`** compiles into a `LEFT JOIN` on the main query, so the related row arrives on the same
+  row and is attached by `OneToOneRelationHydrator` during hydration.
+- **`Many`** and **`ManyToMany`** register an `IBuilderMiddleware` that issues a follow-up query
+  in `afterHydration`, keyed on the parent keys just loaded.
+- **Recursive** relations use a `WITH RECURSIVE` CTE.
+
+A `One` relation nested under a `OneToManyRelation` deliberately does not inherit the parent
+relation, to keep column aliases and hydration separate.
+
+## Loading a relation without an instance
+
+`Model.populate(relationName, owner)` builds the query directly. The owner may be a model or a
+bare key.
+
+```ts sample
+import { Connection, Model, ModelBase, Primary, HasMany, Relation } from '@spinajs/orm';
+
+@Connection('default')
+@Model('order_items')
+export class OrderItem extends ModelBase<OrderItem> {
+  @Primary()
+  public Id: number;
+
+  public order_id: number;
+}
+
+@Connection('default')
+@Model('orders')
+export class Order extends ModelBase<Order> {
+  @Primary()
+  public Id: number;
+
+  @HasMany(OrderItem, { foreignKey: 'order_id', primaryKey: 'Id' })
+  public Items: Relation<OrderItem, Order>;
+}
+
+export async function staticPopulate() {
+  return await Order.populate('Items', 1);
+}
+```
+
+`Query` and `Virtual` relations throw here — only `One`, `Many` and `ManyToMany` are supported.
+
+## Custom relation classes
+
+Both `@HasMany` and `@HasManyToMany` accept `type` (a class) or `factory` (a function) to
+replace the default relation object.
+
+```ts sample
+import { Connection, Model, ModelBase, Primary, HasMany, OneToManyRelationList } from '@spinajs/orm';
+
+@Connection('default')
+@Model('order_items')
+export class OrderItem extends ModelBase<OrderItem> {
+  @Primary()
+  public Id: number;
+
+  public order_id: number;
+
+  public Quantity: number;
+
+  public UnitPrice: number;
+}
+
+export class ItemList extends OneToManyRelationList<OrderItem, Order> {
+  public get Total(): number {
+    return [...this].reduce((sum, item) => sum + item.Quantity * item.UnitPrice, 0);
+  }
+}
+
+@Connection('default')
+@Model('orders')
+export class Order extends ModelBase<Order> {
+  @Primary()
+  public Id: number;
+
+  @HasMany(OrderItem, { foreignKey: 'order_id', primaryKey: 'Id', type: ItemList })
+  public Items: ItemList;
+}
+```

--- a/packages/orm/docs/08-unit-of-work.md
+++ b/packages/orm/docs/08-unit-of-work.md
@@ -1,0 +1,447 @@
+# Unit of work — what `save()` does
+
+`model.save()` persists that model **and everything reachable from it** in one transaction. It
+is a different mechanism from `insert()` / `update()`, which write one row each.
+
+```ts sample
+import { Connection, Model, ModelBase, Primary, BelongsTo, HasMany, Relation, SingleRelation } from '@spinajs/orm';
+
+@Connection('default')
+@Model('order_items')
+export class OrderItem extends ModelBase<OrderItem> {
+  @Primary()
+  public Id: number;
+
+  public order_id: number;
+
+  public Sku: string;
+
+  public Quantity: number;
+}
+
+@Connection('default')
+@Model('clients')
+export class Client extends ModelBase<Client> {
+  @Primary()
+  public Id: number;
+
+  public Name: string;
+}
+
+@Connection('default')
+@Model('orders')
+export class Order extends ModelBase<Order> {
+  @Primary()
+  public Id: number;
+
+  public client_id: number;
+
+  public Reference: string;
+
+  @BelongsTo(Client, 'client_id', 'Id')
+  public Client: SingleRelation<Client>;
+
+  @HasMany(OrderItem, { foreignKey: 'order_id', primaryKey: 'Id' })
+  public Items: Relation<OrderItem, Order>;
+}
+
+export async function placeOrder() {
+  const order = new Order({ Reference: 'ORD-1' });
+
+  order.Client.attach(new Client({ Name: 'Acme' }));
+  order.Items.push(new OrderItem({ Sku: 'A-1', Quantity: 2 }));
+  order.Items.push(new OrderItem({ Sku: 'B-2', Quantity: 1 }));
+
+  // One transaction: insert Client, then Order with its client_id, then both items.
+  const result = await order.save();
+
+  return result; // { Inserted: 4, Updated: 0, Deleted: 0, ... }
+}
+```
+
+## The pipeline
+
+```
+save(root)
+  └─ driver.transaction(...)
+       ├─ IdentityMap                    canonicalize instances
+       ├─ SubjectBuilder.collect(root)   breadth-first graph walk
+       ├─ assertSingleConnection         refuse a graph spanning connections
+       ├─ reloadSnapshots                only with { reload: true }
+       ├─ SubjectBuilder.buildFrom       diff into a SubjectSet
+       ├─ SubjectSorter.sort             topological order
+       ├─ SubjectExecutor.execute        run the statements
+       └─ resnapshotRelations            rebase for the next save
+```
+
+## `ISaveOptions` and `ISaveResult`
+
+```ts sample
+import { Connection, Model, ModelBase, Primary, ISaveOptions, ISaveResult } from '@spinajs/orm';
+
+@Connection('default')
+@Model('orders')
+export class Order extends ModelBase<Order> {
+  @Primary()
+  public Id: number;
+
+  public Reference: string;
+}
+
+export async function saving(order: Order): Promise<ISaveResult> {
+  const options: ISaveOptions = {
+    // Re-read every already-persisted model inside the transaction and diff against
+    // that instead of the hydration snapshot. Costs one SELECT per involved table.
+    reload: true,
+    // Rows per batched statement — junction inserts and orphan key lists. Default 100.
+    chunk: 250,
+  };
+
+  return await order.save(options);
+}
+```
+
+`ISaveResult` counts what actually happened: `Inserted`, `Updated`, `Deleted`, `SoftDeleted`,
+`JunctionInserted`, `JunctionDeleted`.
+
+## Traversal rules
+
+Which relations `save()` follows is the single most important thing to understand about it.
+
+| Relation | Followed when |
+| --- | --- |
+| `belongsTo` (`One`) | Its `Value` is set — populated or not. Attaching a model is an explicit act. |
+| `hasMany` (`Many`) | **`Populated === true` only.** |
+| `manyToMany` | **`Populated === true` only.** |
+| `Query`, `Virtual` | Never. They are read-only projections. |
+
+The `Populated` requirement is a deliberate anti-footgun and the main divergence from TypeORM:
+
+> A relation that was never populated is invisible. `Items` on a freshly constructed model
+> deletes nothing.
+
+Without it, loading an order without its items and saving it would delete every item — the
+in-memory list is empty, so the diff would read "all members removed".
+
+```ts sample
+import { Connection, Model, ModelBase, Primary, HasMany, Relation } from '@spinajs/orm';
+
+@Connection('default')
+@Model('order_items')
+export class OrderItem extends ModelBase<OrderItem> {
+  @Primary()
+  public Id: number;
+
+  public order_id: number;
+
+  public Sku: string;
+}
+
+@Connection('default')
+@Model('orders')
+export class Order extends ModelBase<Order> {
+  @Primary()
+  public Id: number;
+
+  public Reference: string;
+
+  @HasMany(OrderItem, { foreignKey: 'order_id', primaryKey: 'Id' })
+  public Items: Relation<OrderItem, Order>;
+}
+
+export async function safeByDefault() {
+  const order = await Order.getOrFail(1);
+
+  order.Reference = 'ORD-RENAMED';
+
+  // Items was never populated => the relation is invisible => no item is touched.
+  await order.save();
+}
+
+export async function intentionalRemoval() {
+  const order = await Order.getOrFail(1);
+
+  // Now the relation IS populated, so its membership is diffed and enforced.
+  await order.Items.populate();
+  order.Items.remove((item) => item.Sku === 'OBSOLETE');
+
+  await order.save();
+}
+```
+
+## Identity map
+
+Before anything else, every model reached is canonicalized: a row reached by two relation paths
+yields **one instance**, and therefore one subject rather than two conflicting ones.
+
+It is keyed by `(table name, primary key)` — not by constructor. A `@DiscriminationMap` produces
+several constructors for one table, and a subclass instance is still the same row.
+
+Key rendering (`identityKey`) is type-tagged so `1` and `'1'` never collide, handles `Buffer`
+keys as hex, and length-prefixes each part of a composite tuple so `[1, 2]` and `['1,2']` cannot
+alias. A key with any part missing renders as `null` and the model is not registered — it has no
+identity yet.
+
+It is **not a cache**. Nothing outside a `save()` consults it, and it is discarded with the
+transaction. Saves nested inside one transaction share it, so a row touched by two of them is
+still one object.
+
+## Classification
+
+Each collected model becomes a `Subject` with one operation:
+
+| Operation | When |
+| --- | --- |
+| `Insert` | `model.Snapshot === null` — never hydrated from the database. |
+| `Update` | Snapshot diff is non-empty. |
+| `None` | Nothing changed. |
+
+Classification is deliberately **not** keyed on the primary key: `setDefaults()` pre-fills
+`@Uuid` keys at construction, so a brand-new model can already have one.
+
+## Deltas
+
+Alongside subjects, the builder records:
+
+**`IRelationDelta`** per populated `hasMany`: `Added` (members with no snapshot), `Kept`
+(members that had one), `RemovedKeys` (keys in the snapshot that are gone from the array).
+
+Both added *and* kept members receive the owner's foreign key as pending. That is what makes
+re-parenting work: a clean child moved to another owner has its key rewritten and is promoted
+from a no-op to an `UPDATE`.
+
+**`IJunctionDelta`** per populated `manyToMany`. Only the *junction row* is created or
+destroyed. A newly-linked target gets its own insert subject from the graph walk; an unlinked
+target is left completely alone — removing a tag from an order must never delete the tag.
+
+**`IOrphanDelta`** per `hasMany` removal — see below.
+
+## Orphan policy
+
+What happens to a row removed from a `hasMany`.
+
+| Policy | Effect |
+| --- | --- |
+| `nullify` (default) | Clear the child's foreign key, leaving the row. |
+| `delete` | Delete the child row. |
+| `soft-delete` | Stamp the child's `@SoftDelete` column. Requires the target to have one. |
+| `disable` | Do nothing; you manage orphans yourself. |
+
+```ts sample
+import { Connection, Model, ModelBase, Primary, HasMany, Relation, OrphanPolicy } from '@spinajs/orm';
+
+@Connection('default')
+@Model('order_items')
+export class OrderItem extends ModelBase<OrderItem> {
+  @Primary()
+  public Id: number;
+
+  public order_id: number;
+}
+
+@Connection('default')
+@Model('orders')
+export class Order extends ModelBase<Order> {
+  @Primary()
+  public Id: number;
+
+  @HasMany(OrderItem, { foreignKey: 'order_id', primaryKey: 'Id', orphan: OrphanPolicy.Delete })
+  public Items: Relation<OrderItem, Order>;
+}
+```
+
+### When no policy is declared
+
+The default is `nullify`. But when the child's foreign key **demonstrably cannot hold NULL** —
+the column is present in the target descriptor, was reflected from the database (non-empty
+`NativeType`), and is declared non-nullable — `nullify` cannot work either, and the ORM
+**throws**:
+
+```
+relation Items on OrderItem removes rows whose foreign key order_id is NOT NULL, so the
+default orphan policy 'nullify' cannot be applied. Declare what should happen explicitly:
+@HasMany(..., { orphan: OrphanPolicy.Delete }) to remove the row, OrphanPolicy.SoftDelete to
+stamp it, or OrphanPolicy.Disable to leave it alone. Removing rows is never inferred from
+schema nullability.
+```
+
+An earlier version silently escalated to `DELETE`. It throws now on the reasoning that a
+`nullify` the database rejects is a loud, recoverable failure, while a wrong `DELETE` is not.
+
+The `NativeType` check matters in the other direction too: `_prepareColumnDesc` defaults
+`Nullable` to `false`, so without it every model whose table info has not loaded would become a
+hard error.
+
+`soft-delete` on a target with no `@SoftDelete` column throws at resolution time.
+
+### Re-parenting is not orphaning
+
+Orphans are computed once over the **whole set**, not per relation, because the decision needs
+global information. Every removed key that has a live subject of the same target table
+elsewhere in the graph is subtracted — moving a child from one owner to another is a re-parent,
+and only a set-wide view can tell the two apart.
+
+### `delete` degrades to `soft-delete`
+
+An orphan policy of `delete` on a model that declares `@SoftDelete` is applied as `soft-delete`.
+`ModelBase.destroy()` has always stamped rather than deleted for such a model; letting an orphan
+take the other branch would make "delete this row" depend on which code path reached it.
+
+## Ordering
+
+`SubjectSorter` runs Kahn's algorithm over the insert subjects in O(V + E), producing an order
+where every parent precedes every child that references it. It is **stable**: a dependency-free
+graph comes out exactly as it went in.
+
+In-degree counts **distinct** targets — two foreign keys on one subject pointing at the same
+parent are one dependency, and double-counting would leave a counter that never reaches zero
+and a spurious cycle report.
+
+### Cycles
+
+When nothing can proceed, the sorter tries `deferSelfReferences`: foreign keys pointing at the
+**same table** (a self-referencing hierarchy — a cycle between models but not between rows) are
+moved to `DeferredForeignKeys`. The row is inserted without that column and a follow-up `UPDATE`
+sets it.
+
+A genuine cycle between two different models cannot be broken this way and throws
+`OrmCycleException`:
+
+```
+cannot order INSERTs: foreign-key cycle between models A -> B. Break the cycle by saving one
+side first, or make one of the foreign keys deferrable by pointing it at the same model.
+```
+
+Orphan deltas are ordered children-before-parents, so a `DELETE` never strands a foreign key.
+
+## Execution
+
+`SubjectExecutor` runs four phases in order: **inserts → updates → junctions → orphans**.
+
+Every statement goes through `createQuery`, so table naming, schema qualification and identifier
+escaping match the ActiveRecord paths. No connection is threaded by hand — `transaction()`
+carries it in `AsyncLocalStorage`.
+
+### Inserts
+
+**One statement per row, deliberately, and not subject to `chunk`.** A batched multi-row insert
+can only return keys where the dialect supports `RETURNING` or `insertIdIsFirstOfBatch` holds,
+and a subject's key is needed by the very next subject in the order.
+
+For each row: generate client-side keys, assert `assigned` keys, request `RETURNING` when an
+`auto` key needs to come back and the dialect supports it, then backfill.
+
+The insert payload starts from `model.toSql()`, drops every deferred foreign-key column, then
+overwrites each pending foreign key from its target's now-known key. That overwrite matters:
+`StandardModelToSqlConverter` already wrote the column from the relation object, and for a
+target inserted moments ago that value was `undefined` at serialization time.
+
+Backfill uses `setPkValue`, not the `PrimaryKeyValue` setter — the setter's `One` branch also
+writes the new key onto the owner's `SingleRelation` wrapper, which persists nothing.
+
+### Updates
+
+The update payload resolves pending **and** deferred foreign keys onto the model first, *then*
+re-reads `changedColumns()`. This is the single place that decides whether a row really changed:
+a re-parented child that was clean when subjects were built is caught here and nowhere else.
+
+An empty payload emits nothing. Primary key columns are excluded from the `SET` list. `@UpdatedAt`
+is stamped when something is written.
+
+Subjects classified `None` that carry a pending foreign key are included in the update phase for
+exactly this reason — excluding them would lose the move.
+
+### Junctions
+
+Rows are written **column-first** rather than through the junction model, so a junction model is
+not required to declare `@BelongsTo` on both sides (which `ManyToManyRelationList.update()` does
+require).
+
+Inserts run before deletes, so re-linking the same pair inside one save cannot momentarily
+violate a unique constraint on the junction table.
+
+Both are batched by `chunk`.
+
+### Orphans
+
+`nullify` and `soft-delete` run first as `UPDATE`s, then `delete` runs as `DELETE`s. Batched by
+`chunk`. These builders are unfiltered — `createQuery` only adds the `DeletedAt IS NULL` filter
+to select builders — which is what stamping an already-soft-deleted row needs.
+
+## `{ reload: true }`
+
+Re-reads every already-persisted model's row inside the transaction, batched one `SELECT` per
+model class, and performs a **three-way merge** between the hydration baseline, the model, and
+the current row:
+
+- a column **you edited** keeps your value and is rebased, so it is written;
+- a column **you did not touch** is reset to the current database value on the model *and* in
+  the baseline, so it drops out of the diff and is not written at all.
+
+Moving only the baseline would do the opposite of the intent: the model would still hold the
+stale value, the diff would report `current → stale`, and the `UPDATE` would clobber whatever
+another process wrote. The model has to move too.
+
+A row that has **disappeared** has its snapshot cleared, reclassifying the model as an `INSERT`
+that re-creates it, rather than an `UPDATE` matching nothing.
+
+This is last-write-wins rebasing, **not conflict detection**. Two callers editing the same
+column still race, and neither is told.
+
+## Single-connection constraint
+
+```
+save() cannot span connections: Order is on connection main but Log is on connection audit.
+Save each connection's graph separately.
+```
+
+The transaction covers one connection; committing half a graph is not an option.
+
+## After a successful save
+
+`resnapshotRelations` re-records every populated relation's member keys, so a second `save()` on
+the same graph sees no membership change and emits nothing. `Query` and `Virtual` relations are
+skipped.
+
+## Driving the pieces directly
+
+The executor deliberately does **not** open the transaction — `UnitOfWork` does — so you can
+drive the pipeline yourself, which is what the ORM's own tests do.
+
+```ts sample
+import { Connection, Model, ModelBase, Primary, SubjectBuilder, SubjectSorter, SubjectExecutor, IdentityMap } from '@spinajs/orm';
+
+@Connection('default')
+@Model('orders')
+export class Order extends ModelBase<Order> {
+  @Primary()
+  public Id: number;
+
+  public Reference: string;
+}
+
+export async function inspectPlan(root: Order) {
+  const builder = new SubjectBuilder(new IdentityMap());
+
+  const models = builder.collect(root);
+  const set = builder.buildFrom(models);
+  const plan = new SubjectSorter().sort(set);
+
+  // What would run, without running it.
+  const summary = {
+    inserts: plan.Inserts.map((s) => s.Identity),
+    updates: plan.Updates.map((s) => s.Identity),
+    junctions: plan.Junctions.length,
+    orphans: plan.Orphans.length,
+    empty: set.IsEmpty,
+  };
+
+  // And then, if you want to execute it — inside your own transaction.
+  const result = await new SubjectExecutor({}).execute(plan);
+
+  return { summary, result };
+}
+```
+
+`Subject.Identity` renders as `Model#key`, or `Model#<new>` before the key exists. It is for
+diagnostics only and is never used as a map key.

--- a/packages/orm/docs/09-transactions.md
+++ b/packages/orm/docs/09-transactions.md
@@ -1,0 +1,205 @@
+# Transactions
+
+`OrmDriver.transaction(callback, options?)` owns the whole lifecycle: it commits when the
+callback resolves, rolls back when it throws, and releases the connection exactly once on every
+exit path. It resolves with whatever the callback returned.
+
+```ts sample
+import { DI } from '@spinajs/di';
+import { OrmDriver } from '@spinajs/orm';
+
+export async function basic() {
+  const driver = DI.resolve<OrmDriver>('OrmConnection', ['default'])!;
+
+  const total = await driver.transaction(async () => {
+    await driver.insert().into('audit').values({ Message: 'start' });
+    await driver.update().in('counters').update({ Value: 1 }).where('Key', 'runs');
+
+    return 42; // becomes the result of transaction()
+  });
+
+  return total;
+}
+```
+
+## The ambient connection
+
+Statements issued inside the callback run on that transaction's connection **automatically**.
+The per-transaction context is carried through `AsyncLocalStorage`, so nothing has to be threaded
+by hand — this is why the callback's `driver` argument is usually ignored.
+
+The context lives on the abstract `OrmDriver`, not in any one driver, so the guarantee is part
+of the contract that every driver inherits.
+
+```ts sample
+import { DI } from '@spinajs/di';
+import { OrmDriver, ITransactionContext } from '@spinajs/orm';
+
+export function inspect() {
+  const driver = DI.resolve<OrmDriver>('OrmConnection', ['default'])!;
+
+  // undefined outside a transaction.
+  const ctx: ITransactionContext | undefined = driver.CurrentTransaction;
+
+  return ctx?.depth;
+}
+```
+
+`ITransactionContext` carries `connection` (the driver's own handle, absent for single-handle
+drivers like SQLite), `depth` (savepoints taken so far, 0 at the outermost level), and
+`IdentityMap` — created lazily by the first `save()` inside the transaction and discarded with
+it.
+
+## Nesting takes savepoints
+
+Calling `transaction()` while one is already in scope on this async path does **not** open a
+second, independent transaction. It takes a savepoint named `sp_<depth>`, so a failing nested
+block rolls back only its own work and the enclosing transaction survives.
+
+```ts sample
+import { Connection, Model, ModelBase, Primary } from '@spinajs/orm';
+
+@Connection('default')
+@Model('accounts')
+export class Account extends ModelBase<Account> {
+  @Primary()
+  public Id: number;
+
+  public Balance: number;
+
+  public Note: string;
+}
+
+export async function nested() {
+  return await Account.transaction(async () => {
+    const account = await Account.getOrFail(1);
+    account.Balance -= 100;
+    await account.update();
+
+    try {
+      // A savepoint, not a new transaction.
+      await Account.transaction(async () => {
+        account.Note = 'optional bookkeeping';
+        await account.update();
+        throw new Error('this part failed');
+      });
+    } catch {
+      // Only the inner block was rolled back. The balance change is still pending.
+    }
+
+    return account.Balance;
+  });
+}
+```
+
+This is why `save()`, `Relation.sync()` and `SingleRelation.set()` can each open a transaction
+without stepping on a caller who already opened one.
+
+## Isolation levels
+
+`ITransactionOptions.isolation` accepts `READ UNCOMMITTED`, `READ COMMITTED`, `REPEATABLE READ`
+and `SERIALIZABLE`. Which of these a driver honours is declared per driver in
+`SupportedIsolationLevels`, and requesting an unlisted one is **rejected rather than silently
+ignored**:
+
+```
+isolation level SERIALIZABLE not supported by driver orm-driver-x
+```
+
+| Driver | Supported levels |
+| --- | --- |
+| MySQL | all four |
+| MSSQL | all four |
+| SQLite | `SERIALIZABLE` only — sqlite3 outside shared-cache mode serializes file access, which is SERIALIZABLE and nothing else |
+
+A driver that declares nothing rejects every explicitly requested level. Omitting `isolation`
+always works.
+
+Nested calls ignore `isolation`: they map onto savepoints inside the enclosing transaction and
+inherit its isolation.
+
+```ts sample
+import { DI } from '@spinajs/di';
+import { OrmDriver } from '@spinajs/orm';
+
+export async function isolated() {
+  const driver = DI.resolve<OrmDriver>('OrmConnection', ['default'])!;
+
+  return await driver.transaction(
+    async () => {
+      return await driver.select().from('ledger').where('Posted', false);
+    },
+    { isolation: 'REPEATABLE READ' },
+  );
+}
+```
+
+## From a model
+
+`Model.transaction(callback)` runs on that model's connection.
+
+```ts sample
+import { Connection, Model, ModelBase, Primary } from '@spinajs/orm';
+
+@Connection('default')
+@Model('orders')
+export class Order extends ModelBase<Order> {
+  @Primary()
+  public Id: number;
+
+  public Reference: string;
+
+  public Status: string;
+}
+
+export async function place(reference: string) {
+  return await Order.transaction(async () => {
+    const order = new Order({ Reference: reference, Status: 'new' });
+    await order.insert();
+    return order.Id;
+  });
+}
+```
+
+## Rollback semantics
+
+On a throw the driver rolls back and re-throws the original error. A **rollback failure is
+swallowed** so it cannot mask whatever actually went wrong. `_dispose` then runs in a `finally`,
+so the connection is released exactly once whichever path was taken.
+
+Note that a rollback undoes the *database* work only. In-memory model state is not reverted —
+a model whose `insert()` succeeded inside a rolled-back transaction still holds the key the
+database assigned, and that key no longer exists. Re-read or discard such instances.
+
+## What is already transactional
+
+Several ORM operations open a transaction internally, and all of them nest correctly:
+
+| Operation | Why |
+| --- | --- |
+| `model.save()` | The whole graph must apply atomically. |
+| `Relation.sync()` | The writes and the orphan delete used to be independent statements. |
+| `Relation.update()` | Same, for the write half. |
+| `SingleRelation.set()` | The attach and the owner update cannot half-apply. |
+| `SingleRelation.remove()` | Deleting the target and clearing the foreign key cannot half-apply. |
+| A migration | Only with `Migration.Transaction.Mode = PerMigration`. |
+
+## Driver contract
+
+A driver implements six primitives; `transaction()` orchestrates them.
+
+| Method | Responsibility |
+| --- | --- |
+| `_begin(options?)` | Open a transaction, return its context. Pooled drivers acquire a connection here. |
+| `_commit(ctx)` | Commit. |
+| `_rollback(ctx)` | Roll back. |
+| `_savepoint(ctx, name)` | Take a named savepoint. |
+| `_releaseSavepoint(ctx, name)` | The nested block succeeded; fold its changes in. |
+| `_rollbackToSavepoint(ctx, name)` | Discard everything since the savepoint. |
+| `_dispose(ctx)` | Release whatever `_begin` acquired. Called exactly once, on every path. |
+
+## Retries and transactions
+
+`withReconnect` never retries inside a transaction. The connection carried uncommitted state;
+reconnecting and replaying one statement would silently apply it **outside** the transaction. The
+error surfaces instead. See [13-observability.md](13-observability.md).

--- a/packages/orm/docs/10-schema-and-migrations.md
+++ b/packages/orm/docs/10-schema-and-migrations.md
@@ -1,0 +1,501 @@
+# Schema and migrations
+
+## Migrations
+
+A migration extends `OrmMigration` and carries `@Migration(connectionName)`. The decorator
+registers it under the `__migrations__` DI key.
+
+### The name is data
+
+The class name **must** end in `_yyyy_MM_dd_HH_mm_ss`, matched by
+`/(.*)_([0-9]{4}_[0-9]{2}_[0-9]{2}_[0-9]{2}_[0-9]{2}_[0-9]{2})/`. The stamp is parsed with luxon
+and used to order migrations. A name that does not match throws:
+
+```
+Migration file X have invalid name format ( invalid migration name, expected:
+some_name_yyyy_MM_dd_HH_mm_ss got X )
+```
+
+### The three hooks
+
+```ts sample
+import { Migration, OrmMigration, OrmDriver, ReferentialAction } from '@spinajs/orm';
+
+@Migration('default')
+export class CreateShop_2026_07_27_10_00_00 extends OrmMigration {
+  /**
+   * Schema changes. Model classes are NOT usable here — the ORM has not wired
+   * them up yet. Use the schema builder and raw queries only.
+   */
+  public async up(connection: OrmDriver): Promise<void> {
+    await connection.schema().createTable('clients', (table) => {
+      table.int('Id').primaryKey().autoIncrement();
+      table.string('Name', 128).notNull();
+      table.dateTime('CreatedAt').notNull();
+    });
+
+    await connection.schema().createTable('orders', (table) => {
+      table.int('Id').primaryKey().autoIncrement();
+      table.int('client_id').notNull();
+      table.string('Reference', 64).notNull().unique();
+      table.decimal('Total', 12, 2).notNull();
+
+      table.foreignKey('client_id').references('clients', 'Id').onDelete(ReferentialAction.Cascade).onUpdate(ReferentialAction.Cascade);
+    });
+  }
+
+  /** Undo `up`. */
+  public async down(connection: OrmDriver): Promise<void> {
+    await connection.schema().dropTable('orders');
+    await connection.schema().dropTable('clients');
+  }
+
+  /**
+   * Data seeding. Runs AFTER the ORM has fully initialised, so models and
+   * relations are available here.
+   */
+  public async data(): Promise<void> {
+    // await Client.insert({ Name: 'Acme' });
+  }
+}
+```
+
+`up()` runs during `Orm.resolve()`, before models are wired — that is why `data()` exists as a
+separate hook that runs afterwards, only for migrations applied in that same run.
+
+### The lifecycle
+
+For each connection, in migration-timestamp order:
+
+1. Read `Migration.Table` (default `spinajs_migration`). If the table does not exist, create it
+   with a unique `Migration` string column and a `CreatedAt` datetime.
+2. Look for a row naming this migration.
+3. `up()` runs only when **no** row exists; `down()` runs only when one **does**.
+4. Wrap in a transaction when `Migration.Transaction.Mode === PerMigration`.
+5. On `up`, insert the row; on `down`, delete it.
+
+`migrateDown` reverses the order.
+
+### Running them by hand
+
+```ts sample
+import { DI } from '@spinajs/di';
+import { Orm } from '@spinajs/orm';
+
+export async function migrate() {
+  const orm = await DI.resolve(Orm);
+
+  // Everything pending. `force = true` (the default) ignores Migration.OnStartup.
+  const applied = await orm.migrateUp();
+
+  // Just one, by class name.
+  await orm.migrateUp('CreateShop_2026_07_27_10_00_00');
+
+  // Roll back.
+  await orm.migrateDown('CreateShop_2026_07_27_10_00_00');
+
+  return applied;
+}
+```
+
+`migrateUp` resolves with the migrations it actually applied. During `Orm.resolve()` it is
+called with `force = false`, so only connections with `Migration.OnStartup` are touched.
+
+## The schema builder
+
+`connection.schema()` returns a `SchemaQueryBuilder`.
+
+| Method | Returns |
+| --- | --- |
+| `createTable(name, cb)` | `TableQueryBuilder` |
+| `alterTable(name, cb)` | `AlterTableQueryBuilder` |
+| `dropTable(name, schema?)` | `DropTableQueryBuilder` |
+| `dropView(name, schema?)` | `DropViewQueryBuilder` |
+| `cloneTable(cb)` | `CloneTableQueryBuilder` |
+| `tableExists(name, schema?)` | `Promise<boolean>` |
+| `event(name)` / `dropEvent(name)` | `EventQueryBuilder` / `DropEventQueryBuilder` |
+| `raw(query, bindings?)` | `RawSchemaQueryBuilder` |
+
+Every builder is thenable — `await` it to run it.
+
+## Creating a table
+
+### Column types
+
+Each `ColumnType` value becomes a method on `TableQueryBuilder`, installed onto the prototype at
+module load.
+
+| Group | Methods |
+| --- | --- |
+| Integers | `tinyint` `smallint` `mediumint` `int` `bigint` |
+| Text | `tinytext` `text` `mediumtext` `longtext` `string(name, length?)` |
+| Numeric | `float(name, precision?, scale?)` `double(...)` `decimal(...)` |
+| Boolean | `boolean` `bit` |
+| Temporal | `date` `time` `dateTime` `timestamp` |
+| Structured | `enum(name, values)` `json` `set(name, allowed)` |
+| Binary | `binary(name, size)` `tinyblob` `mediumblob` `longblob` |
+
+Two shorthands:
+
+- `increments(name)` — `int(name).autoIncrement().notNull().primaryKey()`
+- `uuid(name)` — `binary(name, 16)`, matching what `UuidConverter` writes
+
+### Column modifiers
+
+Every column method returns a `ColumnQueryBuilder`:
+
+`notNull()` `unique()` `unsigned()` `autoIncrement()` `primaryKey()` `comment(text)`
+`charset(cs)` `collation(c)` `default()`.
+
+`default()` returns a `DefaultValueBuilder` with `value(v)`, `date()`, `dateTime()` and
+`raw(query)`.
+
+```ts sample
+import { Migration, OrmMigration, OrmDriver, RawQuery } from '@spinajs/orm';
+
+@Migration('default')
+export class CreateProducts_2026_07_27_11_00_00 extends OrmMigration {
+  public async up(connection: OrmDriver): Promise<void> {
+    await connection.schema().createTable('products', (table) => {
+      table.increments('Id');
+      table.uuid('PublicId').notNull().unique();
+
+      table.string('Sku', 64).notNull().unique().comment('Stock keeping unit');
+      table.string('Name', 255).notNull();
+      table.text('Description');
+
+      table.decimal('Price', 12, 2).notNull().unsigned();
+      table.int('Stock').notNull().unsigned().default().value(0);
+
+      table.enum('Status', ['draft', 'live', 'retired']).notNull().default().value('draft');
+      table.set('Tags', ['new', 'sale', 'clearance']);
+      table.json('Attributes');
+
+      table.dateTime('CreatedAt').notNull().default().dateTime();
+      table.dateTime('UpdatedAt');
+      table.dateTime('DeletedAt');
+
+      table.string('Slug', 255).default().raw(RawQuery.create("''"));
+
+      table.comment('Catalogue products');
+      table.charset('utf8mb4');
+    });
+  }
+
+  public async down(connection: OrmDriver): Promise<void> {
+    await connection.schema().dropTable('products');
+  }
+}
+```
+
+### Table-level options
+
+| Method | Effect |
+| --- | --- |
+| `ifExists()` | Emit `IF NOT EXISTS` semantics for the create. |
+| `temporary()` | Create a temporary table. |
+| `trackHistory()` | Turn on history tracking — every change and row is versioned, readable through `@Historical` and `IHistoricalModel`. |
+| `comment(text)` | Table comment. |
+| `charset(cs)` | Table charset. |
+
+### Composite primary keys
+
+Mark each key column with `primaryKey()`. Dialects that cannot express a composite key inline —
+SQLite — clear `InlinePrimaryKey` on the column builders and emit a table-level constraint
+instead. That is handled for you.
+
+```ts sample
+import { Migration, OrmMigration, OrmDriver } from '@spinajs/orm';
+
+@Migration('default')
+export class CreateTenantRecords_2026_07_27_12_00_00 extends OrmMigration {
+  public async up(connection: OrmDriver): Promise<void> {
+    await connection.schema().createTable('composite_table', (table) => {
+      table.int('TenantId').notNull().primaryKey();
+      table.string('Code', 32).notNull().primaryKey();
+      table.string('Name', 128).notNull();
+    });
+  }
+
+  public async down(connection: OrmDriver): Promise<void> {
+    await connection.schema().dropTable('composite_table');
+  }
+}
+```
+
+## Foreign keys
+
+`table.foreignKey(column)` returns a `ForeignKeyBuilder`.
+
+| Method | Effect |
+| --- | --- |
+| `references(table, column)` | The parent table and column. |
+| `onDelete(action)` | `ReferentialAction`. |
+| `onUpdate(action)` | `ReferentialAction`. |
+| `cascade()` | `onDelete(Cascade)` + `onUpdate(Cascade)`. |
+
+`ReferentialAction`: `Cascade`, `SetNull`, `Restrict`, `NoAction` (default), `SetDefault`.
+
+```ts sample
+import { Migration, OrmMigration, OrmDriver, ReferentialAction } from '@spinajs/orm';
+
+@Migration('default')
+export class CreateOrderItems_2026_07_27_13_00_00 extends OrmMigration {
+  public async up(connection: OrmDriver): Promise<void> {
+    await connection.schema().createTable('order_items', (table) => {
+      table.increments('Id');
+      table.int('order_id').notNull();
+      table.int('product_id');
+
+      table.foreignKey('order_id').references('orders', 'Id').cascade();
+      table.foreignKey('product_id').references('products', 'Id').onDelete(ReferentialAction.SetNull);
+    });
+  }
+
+  public async down(connection: OrmDriver): Promise<void> {
+    await connection.schema().dropTable('order_items');
+  }
+}
+```
+
+## Indexes
+
+Indexes come from the connection, not the table builder.
+
+```ts sample
+import { Migration, OrmMigration, OrmDriver } from '@spinajs/orm';
+
+@Migration('default')
+export class IndexOrders_2026_07_27_14_00_00 extends OrmMigration {
+  public async up(connection: OrmDriver): Promise<void> {
+    await connection.index().name('idx_orders_client').table('orders').columns(['client_id']);
+
+    await connection.index().name('uq_orders_reference').table('orders').columns(['Reference']).unique();
+  }
+
+  public async down(_connection: OrmDriver): Promise<void> {
+    // Drop through raw SQL — there is no dropIndex builder.
+  }
+}
+```
+
+## Altering a table
+
+`AlterTableQueryBuilder` exposes the same column-type methods, each returning an
+`AlterColumnQueryBuilder` with three modes.
+
+| Method | Effect |
+| --- | --- |
+| `addColumn()` | Add the column. **The default.** |
+| `modify()` | Change the existing column's definition. |
+| `rename(newName)` | Rename it. |
+| `after(column)` | Position it. |
+
+Plus, on the table builder itself: `rename(newTableName)` and `dropColumn(column)`.
+
+```ts sample
+import { Migration, OrmMigration, OrmDriver } from '@spinajs/orm';
+
+@Migration('default')
+export class AlterProducts_2026_07_27_15_00_00 extends OrmMigration {
+  public async up(connection: OrmDriver): Promise<void> {
+    await connection.schema().alterTable('products', (table) => {
+      table.string('Barcode', 32).addColumn().after('Sku');
+      table.string('Name', 512).modify();
+      table.string('Description').rename('LongDescription');
+      table.dropColumn('Obsolete');
+    });
+
+    await connection.schema().alterTable('products', (table) => {
+      table.rename('catalogue_products');
+    });
+  }
+
+  public async down(connection: OrmDriver): Promise<void> {
+    await connection.schema().alterTable('catalogue_products', (table) => {
+      table.rename('products');
+    });
+  }
+}
+```
+
+`AlterTableQueryBuilder.toDB()` returns an **array** of compiled statements — most dialects need
+one statement per alteration.
+
+## Dropping and cloning
+
+```ts sample
+import { Migration, OrmMigration, OrmDriver } from '@spinajs/orm';
+
+@Migration('default')
+export class Housekeeping_2026_07_27_16_00_00 extends OrmMigration {
+  public async up(connection: OrmDriver): Promise<void> {
+    await connection.schema().dropTable('legacy_orders');
+    await connection.schema().dropView('v_legacy').ifExists();
+
+    // Structure only.
+    await connection.schema().cloneTable((clone) => {
+      clone.shallowClone('orders', 'orders_backup');
+    });
+
+    // Structure plus a filtered subset of the data.
+    await connection.schema().cloneTable((clone) => {
+      void clone.deepClone('orders', 'orders_2026', (query) => {
+        query.where('CreatedAt', '>', '2026-01-01');
+      });
+    });
+  }
+
+  public async down(connection: OrmDriver): Promise<void> {
+    await connection.schema().dropTable('orders_backup').ifExists();
+    await connection.schema().dropTable('orders_2026').ifExists();
+  }
+}
+```
+
+`deepClone` is `async` and returns a promise of the builder; `void`-ing it inside a synchronous
+callback, as above, is the usual shape.
+
+Truncation lives on the driver and on the model, not on the schema builder:
+`connection.truncate('table')` or `Model.truncate()`.
+
+## Database events
+
+Scheduled jobs inside the database engine. Only dialects whose `supportedFeatures().events` is
+true support them — **MySQL and MSSQL do; SQLite does not.**
+
+```ts sample
+import { Migration, OrmMigration, OrmDriver, RawQueryStatement } from '@spinajs/orm';
+
+@Migration('default')
+export class ScheduleCleanup_2026_07_27_17_00_00 extends OrmMigration {
+  public async up(connection: OrmDriver): Promise<void> {
+    if (!connection.supportedFeatures().events) {
+      return;
+    }
+
+    const event = connection.schema().event('purge_old_sessions');
+
+    event.every().hour(1);
+    event.comment('Delete sessions older than a day');
+    event.do(connection.del().from('sessions').where('CreatedAt', '<', '2026-01-01'));
+
+    await event;
+  }
+
+  public async down(connection: OrmDriver): Promise<void> {
+    if (!connection.supportedFeatures().events) {
+      return;
+    }
+
+    await connection.schema().dropEvent('purge_old_sessions');
+  }
+}
+```
+
+`EventQueryBuilder`:
+
+| Method | Effect |
+| --- | --- |
+| `every()` | Returns an `EventIntervalDesc` — `second`, `minute`, `hour`, `month`, `year`. Repeats. |
+| `fromNow()` | Same shape, but runs once at `now + interval`. |
+| `at(dateTime)` | Run once at a specific luxon `DateTime`. |
+| `do(sql)` | A `RawQueryStatement`, one `QueryBuilder`, or an array of them. |
+| `comment(text)` | Documentation, passed to the engine. |
+
+`ScheduleQueryBuilder` wraps the same thing with `create(name, cb)` and `drop(name)`.
+
+## Raw DDL
+
+For anything the builders do not cover.
+
+```ts sample
+import { Migration, OrmMigration, OrmDriver, RawQuery } from '@spinajs/orm';
+
+@Migration('default')
+export class RawDdl_2026_07_27_18_00_00 extends OrmMigration {
+  public async up(connection: OrmDriver): Promise<void> {
+    await connection.schema().raw('CREATE VIEW v_active_orders AS SELECT * FROM orders WHERE Status = ?', ['open']);
+
+    await connection.schema().raw(RawQuery.create('CREATE INDEX idx_orders_status ON orders (Status)'));
+  }
+
+  public async down(connection: OrmDriver): Promise<void> {
+    await connection.schema().dropView('v_active_orders').ifExists();
+  }
+}
+```
+
+## Reflecting an existing schema
+
+`driver.tableInfo(name, schema?)` returns `IColumnDescriptor[]`. `Orm.resolve()` calls it for
+every model — it is what makes decorator-free properties into real columns.
+
+```ts sample
+import { DI } from '@spinajs/di';
+import { OrmDriver } from '@spinajs/orm';
+
+export async function reflect() {
+  const driver = DI.resolve<OrmDriver>('OrmConnection', ['default'])!;
+
+  const exists = await driver.schema().tableExists('orders', driver.Options.Database);
+  const columns = exists ? await driver.tableInfo('orders', driver.Options.Database) : [];
+
+  return columns.map((c) => ({
+    name: c.Name,
+    type: c.Type,
+    native: c.NativeType,
+    nullable: c.Nullable,
+    key: c.PrimaryKey,
+  }));
+}
+```
+
+## Model JSON schema
+
+After reflection, each descriptor's `Schema` holds a JSON schema built by
+`buildModelJsonSchema`. `Ignore` columns are excluded and relations omitted; a column is
+`required` when it is neither nullable nor auto-increment.
+
+| SQL type | JSON schema |
+| --- | --- |
+| `tinyint` `smallint` `mediumint` `int` `bigint` | `{ type: 'integer' }` |
+| `decimal` `float` `double` `bit` | `{ type: 'number' }` |
+| `boolean` | `{ type: 'boolean' }` |
+| `date` | `{ type: 'string', format: 'date' }` |
+| `dateTime` `timestamp` | `{ type: 'string', format: 'date-time' }` |
+| `json` | `{ type: 'object' }` |
+| `set` | `{ type: 'array', items: { type: 'string' } }` |
+| anything else | `{ type: 'string' }` |
+
+A column carrying `BooleanValueConverter` is forced to `boolean`. String columns gain
+`maxLength` from `MaxLength`, `description` from `Comment`, and `nullable: true` when nullable.
+
+```ts sample
+import { Connection, Model, ModelBase, Primary, buildModelJsonSchema } from '@spinajs/orm';
+
+@Connection('default')
+@Model('products')
+export class Product extends ModelBase<Product> {
+  @Primary()
+  public Id: number;
+
+  public Sku: string;
+}
+
+export function schema() {
+  const descriptor = Product.getModelDescriptor();
+
+  // Already built during Orm.resolve(); rebuild it explicitly if you changed the columns.
+  return { stored: descriptor.Schema, rebuilt: buildModelJsonSchema(descriptor) };
+}
+```
+
+## Writing migrations that survive
+
+- **Do not import models into `up()`.** They are not wired yet. Use `data()`.
+- **Never edit an applied migration.** The recorded row keeps it from re-running; write a new one.
+- **`down()` is not optional** — `migrateDown` calls it, and an empty `down()` silently corrupts
+  the migration table.
+- **Guard dialect-specific features** with `connection.supportedFeatures()`.
+- **Timestamps order execution**, not file names or discovery order.

--- a/packages/orm/docs/11-converters-and-hydration.md
+++ b/packages/orm/docs/11-converters-and-hydration.md
@@ -1,0 +1,282 @@
+# Converters and hydration
+
+Three separate mechanisms move data across the model / database boundary:
+
+| Direction | Mechanism |
+| --- | --- |
+| Row → model | **Hydrators** (`ModelHydrator`), which call each column's converter `fromDB`. |
+| Model → plain object | **Dehydrators** (`ModelDehydrator`), which call `toDB`. |
+| Model → SQL payload | **`ModelToSqlConverter` / `ObjectToSqlConverter`**, which also call `toDB`. |
+
+## Value converters
+
+`IValueConverter` has two required methods and two optional ones.
+
+```ts sample
+import { ValueConverter, IColumnDescriptor, ModelBase } from '@spinajs/orm';
+
+export class CsvConverter extends ValueConverter {
+  /** Model value -> database value. */
+  public toDB(value: string[], _model: ModelBase, _column: IColumnDescriptor, _options?: unknown): string | null {
+    return value ? value.join(',') : null;
+  }
+
+  /** Database value -> model value. `raw` is the whole row. */
+  public fromDB(value: string, _raw?: unknown, _options?: unknown): string[] {
+    return value ? value.split(',') : [];
+  }
+}
+```
+
+### The snapshot hooks
+
+`snapshotValue(value)` and `snapshotEquals(a, b)` are optional, and you need them **together**
+whenever `fromDB` returns a **mutable instance of a class the ORM does not own**.
+
+Without them the diff baseline can only either alias the live object — making the diff
+permanently empty, so edits to that column are silently never written — or treat the column as
+always-changed. The ORM takes the second, loud option; these hooks are how a converter opts into
+a precise diff instead.
+
+Immutable value types need neither: reference equality already answers the question.
+
+```ts sample
+import { ValueConverter, IColumnDescriptor, ModelBase } from '@spinajs/orm';
+
+/** A mutable value object the ORM cannot copy on its own. */
+export class Money {
+  constructor(public Amount: number, public Currency: string) {}
+}
+
+export class MoneyConverter extends ValueConverter {
+  public toDB(value: Money, _model: ModelBase, _column: IColumnDescriptor): string | null {
+    return value ? `${value.Amount}:${value.Currency}` : null;
+  }
+
+  public fromDB(value: string): Money | null {
+    if (!value) return null;
+    const [amount, currency] = value.split(':');
+    return new Money(Number(amount), currency);
+  }
+
+  /** Copy, never alias — an aliased baseline makes every diff empty. */
+  public snapshotValue(value: Money | null): Money | null {
+    return value ? new Money(value.Amount, value.Currency) : null;
+  }
+
+  public snapshotEquals(a: Money | null, b: Money | null): boolean {
+    if (a === b) return true;
+    if (!a || !b) return false;
+    return a.Amount === b.Amount && a.Currency === b.Currency;
+  }
+}
+```
+
+### Attaching a converter
+
+Two routes.
+
+**Per column, by decorator.** `@Json`, `@Set`, `@DateTime`, `@UniversalConverter`, `@Uuid`,
+`@CreatedAt`, `@UpdatedAt`, `@SoftDelete` and `@Archived` all register into
+`descriptor.Converters`.
+
+**Per database type, by DI.** During `Orm.resolve()`, `registerDefaultConverters` maps native
+type names into `__orm_db_value_converters__`:
+
+| Key | Converter |
+| --- | --- |
+| `Date`, `DateTime` | `DatetimeValueConverter` |
+| `Boolean`, `bool`, `Bool`, `boolean` | `BooleanValueConverter` |
+| `Time`, `time`, `TimeSpan`, `timespan` | `TimeValueConverter` |
+
+`reloadTableInfo()` then assigns a converter to any column that has none, matching on the
+column's lowercased `NativeType`.
+
+Decorator-declared converters win: they are applied first, and the type map only fills the gaps.
+
+```ts sample
+import { DI } from '@spinajs/di';
+import { ValueConverter, IColumnDescriptor, ModelBase } from '@spinajs/orm';
+
+export class PointConverter extends ValueConverter {
+  public toDB(value: { x: number; y: number }, _m: ModelBase, _c: IColumnDescriptor): string {
+    return `${value.x},${value.y}`;
+  }
+
+  public fromDB(value: string): { x: number; y: number } {
+    const [x, y] = value.split(',').map(Number);
+    return { x, y };
+  }
+}
+
+/** Every column whose reflected NativeType is `point` now uses it. */
+export function registerPointConverter() {
+  DI.register(PointConverter).asMapValue('__orm_db_value_converters__', 'point');
+}
+```
+
+### Built-in converters
+
+| Converter | Behaviour |
+| --- | --- |
+| `JsonValueConverter` | `JSON.stringify` / `JSON.parse`. `fromDB` passes objects and arrays through untouched, so a native JSON column already parsed by the driver is safe. |
+| `UuidConverter` | Writes a dashed UUID as a 16-byte `Buffer`; reads it back as the canonical 8-4-4-4-12 form. A value that is not 32 hex characters is returned as-is rather than mangled. |
+| `UniversalValueConverter` | Reads the runtime type from a sibling column (`options.TypeColumn`, default `Type`) and converts accordingly. |
+| `DatetimeValueConverter` | Abstract in core; dialects provide the implementation. |
+| `TimeValueConverter` | Abstract in core; dialect-provided. |
+| `BooleanValueConverter` | Abstract in core; dialect-provided. `0`/`1` ↔ boolean. |
+| `SetValueConverter` | Abstract in core; dialect-provided. Emulates MySQL `SET`. |
+
+`UniversalValueConverter` canonical forms: numbers as decimal text, booleans as `'true'` /
+`'false'`, date / time / datetime as ISO 8601, json as JSON. `null` and `undefined` are persisted
+as-is; an empty string is read back as an empty string without parsing.
+
+## Hydrators
+
+`ModelHydrator` subclasses registered under the `ModelHydrator` DI token. `model.hydrate(data)`
+resolves **all** of them and runs each in turn.
+
+| Hydrator | Responsibility |
+| --- | --- |
+| `DbPropertyHydrator` | Keys matching a declared column. Runs `Converter.fromDB`. |
+| `NonDbPropertyHydrator` | Every other key, assigned raw. |
+| `OneToManyRelationHydrator` | A `Many` relation arriving as an array — builds a populated `OneToManyRelationList`. |
+| `OneToOneRelationHydrator` | A `One` relation arriving as an object or a model — builds a populated `SingleRelation`. |
+| `JunctionModelPropertyHydrator` | `@JunctionTable` properties, from `values.JunctionModel`. |
+
+Three behaviours worth knowing:
+
+**A null primary key never overwrites.** `DbPropertyHydrator` skips a key column whose incoming
+value is `null` or `undefined`, so a `LEFT JOIN` miss cannot wipe the target's key.
+
+**A model instance on a foreign-key column is translated to its key.** Passing a resolved model
+under a FK column name (as `@spinajs/orm-http`'s DTO `@Relation` does) stores the primary key,
+not the object.
+
+**Relations hydrate only when the key is present.** Both relation hydrators are guarded by
+`values[key] != null`, so a relation the query did not ask for is never marked `Populated`.
+
+`OneToManyRelationHydrator` also deletes the owner's foreign-key property after building the
+list, and both relation hydrators call `snapshotRelation`.
+
+### Adding one
+
+```ts sample
+import { Injectable } from '@spinajs/di';
+import { ModelHydrator, ModelBase } from '@spinajs/orm';
+
+@Injectable(ModelHydrator)
+export class AuditTrailHydrator extends ModelHydrator {
+  public hydrate(target: ModelBase, values: Record<string, unknown>): void {
+    if (values['__audit__']) {
+      (target as unknown as { AuditTrail: unknown }).AuditTrail = values['__audit__'];
+    }
+  }
+}
+```
+
+## Dehydrators
+
+| Dehydrator | Output |
+| --- | --- |
+| `StandardModelDehydrator` | Columns only. Backs `dehydrate()` and `toJSON()`. |
+| `StandardModelWithRelationsDehydrator` | Columns plus relations, recursed. Backs `dehydrateWithRelations()`. |
+
+`StandardModelDehydrator` skips columns in `options.omit`, and skips a column that is a
+relation's foreign key **unless it is also a primary key**. It runs `Converter.toDB`, then
+applies `skipNull` / `skipUndefined` / `skipEmptyArray`.
+
+It **throws** `Field X cannot be null` for a non-nullable, non-primary-key column holding
+`null`, `undefined` or `''`, unless `ignoreNullable` is set.
+
+`StandardModelWithRelationsDehydrator` emits a `One` relation's dehydrated value when loaded and
+falls back to the raw foreign key otherwise; a `Many` relation becomes an array, `[]` when empty.
+`omit` is **not** propagated into nested relations — the recursive calls pass `omit: []`.
+
+## Model → SQL
+
+`ModelToSqlConverter.toSql(model)` builds the payload for `INSERT` and `UPDATE`.
+`StandardModelToSqlConverter` is registered on every driver's container.
+
+The rules:
+
+1. Serialize every column that is not `Virtual`, **skipping foreign-key columns that an actual
+   relation manages** — those are written from the relation instead. A foreign-key column with
+   *no* backing relation (a plain owner-id column) is serialized normally; skipping those broke
+   inserts against their `NOT NULL` constraints.
+2. **Throw** `Field X cannot be null` for a non-nullable, non-primary-key column holding `null`,
+   `undefined` or `''`.
+3. Run each column's `Converter.toDB`.
+4. For each `One` relation: write the foreign key from the related model's primary key. When the
+   `SingleRelation` has no `Value`, fall back to the raw foreign-key column hydrated from the
+   row — without that fallback `InsertOrUpdate` emits an empty binding and orphans the row.
+5. For a `Recursive` relation, copy the foreign key straight through.
+
+`ObjectToSqlConverter` does the same for a plain object plus a descriptor — it is what
+`Model.insert({...})` uses. It skips `undefined` values entirely and handles `One` relations only
+when the property holds a `ModelBase`.
+
+### Replacing them
+
+Both are registered on the **driver's** container, so an override is per connection.
+
+```ts sample
+import { DI } from '@spinajs/di';
+import { OrmDriver, StandardModelToSqlConverter, ModelToSqlConverter, ModelBase } from '@spinajs/orm';
+
+export class TenantStampingConverter extends StandardModelToSqlConverter {
+  public toSql(model: ModelBase<unknown>): unknown {
+    const payload = super.toSql(model) as Record<string, unknown>;
+    payload['TenantId'] = 7;
+    return payload;
+  }
+}
+
+export function install() {
+  const driver = DI.resolve<OrmDriver>('OrmConnection', ['default'])!;
+  driver.Container.register(TenantStampingConverter).as(ModelToSqlConverter);
+}
+```
+
+## Snapshots
+
+`snapshot.ts` provides the diff baseline machinery.
+
+| Export | Purpose |
+| --- | --- |
+| `createSnapshot()` | An empty `IModelSnapshot` — `{ Columns, Relations }`. |
+| `snapshotValue(value, converter?)` | The value to store as the baseline. |
+| `snapshotEquals(a, b, converter?)` | Baseline-vs-current comparison. |
+| `snapshotFromRow(descriptor, row)` | Build a column baseline from a raw row — used by `save({ reload: true })`. |
+| `UNCOPYABLE` | Sentinel for a value that cannot be copied. |
+
+`snapshotValue` delegates to the converter's `snapshotValue` when it has one. When it does not
+and the value is a mutable instance the ORM cannot copy, it stores `UNCOPYABLE`, which never
+compares equal — so the column reads as always-changed. That is the loud failure mode described
+above, and implementing the two hooks is how you replace it with a precise diff.
+
+## `ServerResponseMapper`
+
+Normalizes a driver's raw insert response into `DbServerResponse`
+(`{ RowsAffected, LastInsertId, Returning }`).
+
+**Every driver must register an implementation.** The base class throws rather than defining a
+default, because the shape of an insert response is dialect-specific:
+
+```
+no ServerResponseMapper is registered for this connection. Every driver must register one:
+container.register(MyMapper).as(ServerResponseMapper)
+```
+
+It is declared as a throwing concrete class rather than an abstract method so a container
+missing the registration names the unimplemented contract, instead of dying with
+`read is not a function` several frames deep inside a result middleware.
+
+## Model middleware
+
+`ModelMiddleware` is an abstract lifecycle hook with `onInsert`, `onUpdate`, `onDelete` and
+`onSelect`, each taking a model and returning a promise. Register subclasses under the
+`ModelMiddleware` token.
+
+For query-level interception — which is what most cross-cutting concerns actually need — use
+`QueryMiddleware` instead; see [06-query-builder.md](06-query-builder.md).

--- a/packages/orm/docs/12-architecture.md
+++ b/packages/orm/docs/12-architecture.md
@@ -1,0 +1,295 @@
+# Architecture
+
+How the pieces fit, for anyone extending or debugging the ORM.
+
+## Layering
+
+```
+  application models
+        │
+  @spinajs/orm            decorators, descriptors, builders, relations, unit of work
+        │                 ── contains no SQL ──
+  @spinajs/orm-sql        SqlDriver + generic SQL statements and compilers
+        │
+  orm-sqlite / orm-mysql / orm-mssql
+                          dialect overrides, connection handling, tableInfo
+```
+
+The core defines **abstract** statement and compiler classes (`WhereStatement`,
+`SelectQueryCompiler`, …). It never instantiates them directly — it resolves them from the
+driver's DI container, which is where a dialect binds its concrete versions. That indirection is
+the whole reason the core can be SQL-free.
+
+## How a query becomes SQL
+
+```
+Model.where('Age', '>', 30)
+  │
+  ├─ createQuery(model, SelectQueryBuilder)
+  │     ├─ read the descriptor
+  │     ├─ resolve the driver from the model's connection
+  │     ├─ resolve the builder from driver.Container
+  │     ├─ set table + alias, add the soft-delete filter
+  │     └─ add DiscriminationMapMiddleware when the model has one
+  │
+  ├─ .where(...)        → container.resolve(WhereStatement, [...])   → SqlWhereStatement
+  │
+  ├─ await              → Builder.execute()  (memoized)
+  │     ├─ QueryMiddleware.beforeQueryExecution for every middleware
+  │     ├─ driver.execute(builder)
+  │     │     └─ SqlDriver.execute: builder.toDB() → executeOnDb(expression, bindings, context)
+  │     │           └─ toDB(): container.resolve(SelectQueryCompiler, [builder]).compile()
+  │     │
+  │     ├─ IBuilderMiddleware.afterQuery on the raw rows
+  │     ├─ per row: modelCreation (reverse order, first non-null wins)
+  │     │           → DI.resolve('__orm_model_factory__', [model])
+  │     │           → model.hydrate(row); IsDirty = false; takeSnapshot()
+  │     │           → snapshotRelation for every already-populated relation
+  │     └─ await IBuilderMiddleware.afterHydration(models)   ← relations load here
+  │
+  └─ SelectQueryBuilder._run unwraps the array when takeFirst() was used
+```
+
+Two ordering details in there are load-bearing.
+
+**The middleware list is snapshotted after the driver call.** Compiling the query is what
+registers the relation middlewares — the driver calls `toDB()` — so that is the first point at
+which the list is complete. Everything downstream runs against an immutable copy, and
+`Array.prototype.reverse()` is never called on the live array (it mutates in place, and used to
+flip `modelCreation` resolution order on every execution).
+
+**The snapshot is taken before `afterHydration`.** That is the one moment when the instance's
+columns hold exactly what the database returned. Relation members attached later by the
+`afterHydration` middlewares record their own member keys into that same snapshot. Relation data
+that arrived *on the row itself* (a `belongsTo` `LEFT JOIN`) was attached by the hydrators before
+the snapshot existed, so their `snapshotRelation` calls no-opped — `_run` re-records those
+immediately after `takeSnapshot()`.
+
+## `createQuery`
+
+Every builder in the ORM is constructed through it, which is what keeps table naming, schema
+qualification, escaping and the soft-delete filter consistent across the ActiveRecord, relation
+and unit-of-work paths.
+
+```ts sample
+import { Connection, Model, ModelBase, Primary, createQuery, SelectQueryBuilder } from '@spinajs/orm';
+
+@Connection('default')
+@Model('users')
+export class User extends ModelBase<User> {
+  @Primary()
+  public Id: number;
+
+  public Name: string;
+}
+
+export async function manual() {
+  // `injectModel: false` produces a builder that returns raw rows rather than models.
+  const { query, description, container, model } = createQuery(User, SelectQueryBuilder);
+
+  return {
+    rows: await query.select('*').where('Name', 'like', 'A%'),
+    table: description.TableName,
+    hasContainer: Boolean(container),
+    modelName: model.name,
+  };
+}
+```
+
+It throws `model X does not have model descriptor. Use @model decorator on class` when the
+descriptor is missing.
+
+## Statements
+
+A statement is one compilable fragment. The core declares them abstract; `@spinajs/orm-sql`
+implements them and each driver overrides what it must.
+
+| Abstract | Concrete in orm-sql |
+| --- | --- |
+| `RawQueryStatement` | `SqlRawStatement` |
+| `WhereStatement` | `SqlWhereStatement` |
+| `WhereQueryStatement` | `SqlWhereQueryStatement` |
+| `BetweenStatement` | `SqlBetweenStatement` |
+| `InStatement` | `SqlInStatement` |
+| `InSetStatement` | `SqlInSetStatement` |
+| `ExistsQueryStatement` | `SqlExistsQueryStatement` |
+| `ColumnStatement` | `SqlColumnStatement` |
+| `ColumnRawStatement` | `SqlColumnRawStatement` |
+| `ColumnMethodStatement` | `SqlColumnMethodStatement` |
+| `JoinStatement` | `SqlJoinStatement` |
+| `GroupByStatement` | `SqlGroupByStatement` |
+| `WithRecursiveStatement` | `SqlWithRecursiveStatement` |
+| `LazyQueryStatement` | `SqlLazyQueryStatement` |
+| `DateWrapper` / `DateTimeWrapper` | `SqlDateWrapper` / `SqlDateTimeWrapper` |
+
+Every statement implements `build(): IQueryStatementResult` and `clone(builder)`. Cloning
+preserves the per-statement boolean connector, which a naive rebuild would reset to `AND`.
+
+`ColumnStatement` validates the column against the model descriptor at construction, allowing
+properties that exist on the prototype without a decorator and primary keys declared only via
+`@Primary`. Anything else throws `column X not exists in model Y`.
+
+## Compilers
+
+One compiler per query shape, all abstract in the core and resolved from the driver's container:
+
+`SelectQueryCompiler` `InsertQueryCompiler` `UpdateQueryCompiler` `DeleteQueryCompiler`
+`OnDuplicateQueryCompiler` `TableQueryCompiler` `AlterTableQueryCompiler`
+`AlterColumnQueryCompiler` `ColumnQueryCompiler` `IndexQueryCompiler`
+`ForeignKeyQueryCompiler` `LimitQueryCompiler` `OrderByQueryCompiler` `GroupByQueryCompiler`
+`JoinQueryCompiler` `RecursiveQueryCompiler` `TruncateTableQueryCompiler`
+`TableCloneQueryCompiler` `TableHistoryQueryCompiler` `TableExistsCompiler`
+`DropTableCompiler` `DropViewCompiler` `EventQueryCompiler` `DropEventQueryCompiler`
+`RawSchemaQueryCompiler`.
+
+Each returns `ICompilerOutput` — `{ expression, bindings }` — or an array of them for
+multi-statement DDL.
+
+`TableAliasCompiler` is a `@Singleton` that renders a table reference with its alias, honouring
+`Options.AliasSeparator`.
+
+## The DI registration map
+
+| Key | Registered by | Purpose |
+| --- | --- | --- |
+| `__models__` | `@Model` | Model discovery. |
+| `__migrations__` | `@Migration` | Migration discovery. |
+| `OrmConnection` | `Orm.createConnections()` | Factory: name → driver, `null` when unknown. |
+| `Orm` | DI | The ORM service itself. |
+| `__orm_model_factory__` | application / driver | Builds a model instance during hydration. |
+| `__orm_relation_has_many_factory__` | driver | Builds a `hasMany` relation object. |
+| `__orm_relation_has_many_to_many_factory__` | driver | Builds a `manyToMany` relation object. |
+| `__orm_db_value_converters__` | `Orm.registerDefaultConverters()` + application | Map of native type name → converter class. |
+| `ModelHydrator` | `hydrators.ts`, application | Hydrator chain. |
+| `QueryMiddleware` | application | Global query hooks. |
+| `ModelMiddleware` | application | Model lifecycle hooks. |
+| `ExistsRelationHandler` | `existsRelationHandlers.ts` | One per relation type, for `whereExists`. |
+| `ServerResponseMapper` | **each driver** | Normalizes insert responses. |
+| `ModelToSqlConverter` / `ObjectToSqlConverter` | `OrmDriver.resolve()` | Model → SQL payload. |
+| every compiler / statement token | driver's `resolve()` | Dialect bindings. |
+
+Note the container hierarchy: `OrmDriver.resolve()` creates a **child container** per driver, so
+every dialect binding is scoped to its own connection. Two connections on different dialects
+coexist without stepping on each other.
+
+## The relation machinery
+
+`IOrmRelation` implementations, resolved by `SelectQueryBuilder._getRelationInstance` from the
+relation's `RelationType`:
+
+| Class | Handles | Strategy |
+| --- | --- | --- |
+| `BelongsToRelation` | `One` | `LEFT JOIN` on the main query. |
+| `BelongsToRecursiveRelation` | `One` + `@Recursive` | Recursive CTE. |
+| `OneToManyRelation` | `Many` | Follow-up query in `afterHydration`. |
+| `ManyToManyRelation` | `ManyToMany` | Junction query plus target join. |
+| `QueryRelation` | `Query` | The decorator's callback. |
+| `VirtualRelation` | `Virtual` | Your relation class. |
+
+Each registers an `IBuilderMiddleware` on the owning builder:
+
+| Middleware | Role |
+| --- | --- |
+| `HasManyRelationMiddleware` | Loads `hasMany` members keyed on the parents just hydrated. |
+| `HasManyToManyRelationMiddleware` | Same, through the junction table. |
+| `BelongsToRelationRecursiveMiddleware` | Assembles a recursive `belongsTo` chain. |
+| `BelongsToPopulateDataMiddleware` | Attaches joined `belongsTo` data. |
+| `BelongsToRelationResultTransformMiddleware` | Reshapes joined columns back into nested objects. |
+| `QueryRelationMiddleware` | Runs a `@Query` relation's callback and mapper. |
+| `VirtualRelationMiddleware` | Delegates to a `@Virtual` relation class. |
+| `DiscriminationMapMiddleware` | Chooses the concrete model class per row. |
+
+A `One` relation nested under a `OneToManyRelation` is deliberately given a `null` owner
+relation, keeping its column aliases and hydration independent of the parent query.
+
+## Descriptor storage
+
+Descriptors are **own** metadata per class, under `MODEL_DESCTRIPTION_SYMBOL`.
+
+`extractModelDescriptor` reads `Reflect.getOwnMetadata` — the class's own descriptor only.
+`extractModelDescriptorInherited` collapses the whole prototype chain onto a fresh default.
+Because every stored descriptor is already collapsed, array fields gain no duplicates per
+inheritance level; the de-duplication a name-keyed store needed is now structural.
+
+The read side must stay paired with the write side in `decorators.ts` `_getMetadataFrom`. Both
+use own-metadata-per-class. The predecessor was a *name-keyed* container, which collapsed two
+classes sharing a name into one slot and broke under minification.
+
+## Primary key helpers
+
+`primary-keys.ts` is the single place that knows a key may be composite. Anything reasoning about
+keys should go through it rather than touching `descriptor.PrimaryKey` directly.
+
+| Function | Purpose |
+| --- | --- |
+| `pkColumns(d)` | Key column names. |
+| `hasPk(d)` / `isCompositePk(d)` | Predicates. |
+| `normalizePkTuple(d, value)` | Scalar / array / object → tuple in key order. |
+| `pkValueOf(source, d)` | Read the key: scalar or tuple. |
+| `setPkValue(target, d, value)` | Write it. |
+| `pkKeyString(source, d)` / `pkKeyStringFor(source, keys)` | Flatten to a string. |
+| `wherePk(builder, d, value)` | `WHERE` for one key. |
+| `whereAnyPk(builder, d, values)` | `WHERE` for many. |
+| `whereNotAnyPk(builder, d, values)` | The negation. |
+| `orderByPk(builder, d, order)` | Order by the key. |
+| `pkGeneration(d, column)` | The column's generation strategy. |
+| `generateClientSideKeys(target, d)` | Fill `uuid` keys. |
+| `assertAssignedKeys(target, d)` | Throw when an `assigned` key is missing. |
+
+## Recurring hazards in this codebase
+
+These show up throughout the source comments and are worth internalising.
+
+**A composite key is a tuple, and a tuple is always truthy.** `if (!pk)` is wrong for a
+composite key — check every element. `destroy()`, `save()`'s reload pass and the executor's
+backfill all do.
+
+**`PrimaryKey` is `string[]`.** Passing it where a column name is expected compiles to a column
+literally named `0`.
+
+**Empty `IN ()` matches nothing.** `whereIn(c, [])` compiles to `FALSE`, never "no condition".
+
+**An empty array is truthy.** `if (description.PrimaryKey)` is true for `[]`; use an explicit
+length check.
+
+**Inherited descriptor members are shared by reference** until detached. See
+[03-models-and-decorators.md](03-models-and-decorators.md).
+
+**A relation joins on exactly one column pair.** Composite keys have no defensible default and
+must be named explicitly.
+
+**Builders execute at most once.** `clone()` for a second round-trip.
+
+## Exceptions
+
+| Exception | Meaning |
+| --- | --- |
+| `OrmException` | Base class. Carries connection options and the offending SQL where available. |
+| `OrmNotFoundException` | `firstOrFail` / `getOrFail` found nothing. Carries the expression and bindings. |
+| `OrmCycleException` | The insert order cannot be satisfied. |
+
+From `@spinajs/exceptions`: `InvalidArgument` (bad value), `InvalidOperation` (bad state),
+`NotSupported` (dialect cannot do it), `MethodNotImplemented` (contract not implemented).
+
+## Metadata models
+
+`metadata.ts` provides `MetadataModel` and `MetadataRelation` — a generic key/value metadata
+table pattern built on `@UniversalConverter`. It is **deliberately not re-exported** from
+`index.ts`, to avoid a circular dependency. Import it directly:
+
+```ts
+import { MetadataModel, MetadataRelation } from '@spinajs/orm/lib/mjs/metadata.js';
+```
+
+## Extension points, ranked by reach
+
+| Point | Scope |
+| --- | --- |
+| `QueryMiddleware` | Every query on every connection. |
+| `IBuilderMiddleware` | One builder. |
+| `ModelHydrator` | Every hydration. |
+| `ValueConverter` | One column, or one database type. |
+| `ModelToSqlConverter` | One connection's write payloads. |
+| Relation `type` / `factory` | One relation. |
+| `QueryScope` | One model's builders. |
+| Custom `OrmDriver` | A whole dialect — see [orm-sql's docs](../../orm-sql/docs/04-writing-a-driver.md). |

--- a/packages/orm/docs/13-observability.md
+++ b/packages/orm/docs/13-observability.md
@@ -1,0 +1,241 @@
+# Observability
+
+Metrics, connection health, retries and logging.
+
+## Connection state
+
+Every driver tracks a `ConnectionState`.
+
+| State | Meaning |
+| --- | --- |
+| `Disconnected` | No usable connection. |
+| `Connecting` | A connect attempt is in flight. |
+| `Connected` | Healthy. |
+| `Degraded` | Reachable but failing health probes, or mid-reconnect. **Queries are still attempted.** |
+
+Transitions are logged: `Connected` at `info`, `Degraded` and `Disconnected` at `warn`, the rest
+at `trace`. A repeat transition to the same state is ignored.
+
+```ts sample
+import { DI } from '@spinajs/di';
+import { OrmDriver, ConnectionState } from '@spinajs/orm';
+
+export function health() {
+  const driver = DI.resolve<OrmDriver>('OrmConnection', ['default'])!;
+
+  return {
+    state: driver.State,
+    healthy: driver.State === ConnectionState.Connected,
+    pool: driver.poolMetrics(),
+  };
+}
+```
+
+## Health checks
+
+`Orm.createConnections()` calls `driver.startHealthCheck()` on every connection as it opens.
+A connection that was healthy at boot says nothing about a pool holding sockets to a database
+that has since restarted, so the probe keeps running for the connection's lifetime.
+
+- Interval: `Resilience.HealthCheckInterval`, default 30000 ms. `0` disables it.
+- The timer is `unref`'d — it never holds the process open.
+- `startHealthCheck()` / `stopHealthCheck()` are idempotent.
+- `orm.dispose()` stops every probe and disconnects.
+
+One probe publishes pool metrics, calls `ping()`, and on failure marks the driver `Degraded` and
+attempts a single reconnect. **It never throws** — it runs on a timer with no caller to receive
+the error.
+
+A successful reconnect does *not* by itself restore `Connected`: a fresh handle is not evidence
+that queries work, so only the next successful probe promotes it. Drivers whose `connect()`
+genuinely verifies the link (MySQL takes and releases a real connection) set the state
+themselves.
+
+## Retries
+
+`withReconnect` wraps an operation and, on a **transport** failure, reconnects and retries with
+bounded exponential backoff. Query errors — a syntax error, a constraint violation — propagate
+on the first attempt untouched.
+
+Backoff is `min(RetryDelay * 2^attempt, MaxRetryDelay)`.
+
+### What counts as retryable
+
+`RETRYABLE_ERROR_CODES` is deliberately narrow — retrying a statement the server rejected only
+multiplies the failure:
+
+`ECONNRESET` `ECONNREFUSED` `EPIPE` `ETIMEDOUT` `EHOSTUNREACH` `ENETUNREACH` `ENOTFOUND`
+`PROTOCOL_CONNECTION_LOST` `PROTOCOL_SEQUENCE_TIMEOUT` `PROTOCOL_ENQUEUE_AFTER_FATAL_ERROR`
+`PROTOCOL_ENQUEUE_AFTER_QUIT` `ER_CON_COUNT_ERROR` `ER_LOCK_WAIT_TIMEOUT` `SQLITE_BUSY`
+
+`isRetryableErrorCode` walks the error's `inner` / `cause` chain up to five levels, because
+driver errors are routinely wrapped (`OrmException` carries the original in `inner`) and a
+shallow check would miss exactly the cases that matter.
+
+```ts sample
+import { isRetryableErrorCode, backoffDelay, RETRYABLE_ERROR_CODES } from '@spinajs/orm';
+
+export function classify(err: unknown) {
+  return {
+    retryable: isRetryableErrorCode(err),
+    firstDelay: backoffDelay(0, 200, 5000),   // 200
+    thirdDelay: backoffDelay(2, 200, 5000),   // 800
+    cappedDelay: backoffDelay(10, 200, 5000), // 5000
+    codes: [...RETRYABLE_ERROR_CODES],
+  };
+}
+```
+
+### Retries never happen inside a transaction
+
+MySQL's driver overrides `isRetryableError` to return `false` whenever a transaction is in
+scope. The connection carried uncommitted state; reconnecting and replaying one statement would
+silently apply it **outside** the transaction. The error surfaces instead.
+
+### Adding dialect codes
+
+```ts sample
+import { SqlDriver } from '@spinajs/orm-sql';
+import { isRetryableErrorCode, QueryContext } from '@spinajs/orm';
+
+const EXTRA_CODES = new Set(['ER_LOCK_DEADLOCK']);
+
+export abstract class MyDriver extends SqlDriver {
+  public abstract executeOnDb(stmt: string | object, params: unknown[], context: QueryContext): Promise<unknown>;
+
+  protected isRetryableError(err: unknown): boolean {
+    if (super.isRetryableError(err)) {
+      return true;
+    }
+
+    const code = (err as { code?: string })?.code;
+    return typeof code === 'string' && EXTRA_CODES.has(code) && isRetryableErrorCode(err);
+  }
+}
+```
+
+## Metrics
+
+The ORM publishes into the shared `Metrics` registry from `@spinajs/telemetry-common`. Nothing
+has to be wired: `@spinajs/telemetry`'s `/metrics` endpoint renders that same singleton.
+
+| Metric | Type | Labels | Meaning |
+| --- | --- | --- | --- |
+| `orm_pool_size` | gauge | `connection` | Open connections (idle + in use). |
+| `orm_pool_in_use` | gauge | `connection` | Connections checked out by a query. |
+| `orm_pool_waiting` | gauge | `connection` | Callers waiting for a free connection. |
+| `orm_connection_state` | gauge | `connection` | `1` when connected, `0` otherwise. |
+| `orm_pool_acquire_seconds` | histogram | `connection` | Seconds spent acquiring a pooled connection. |
+
+Acquire buckets are `[0.0005, 0.001, 0.005, 0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10]` —
+dense at the bottom, because a healthy acquire is sub-millisecond and prom-client's linear
+default (1..10 s) would put every one of them in the first bucket.
+
+Gauges are refreshed on each health tick. `publishPoolMetrics()` and `observeAcquireSeconds()`
+both swallow their own errors: telemetry must never break a connection, and `publishPoolMetrics`
+runs *first* on every health tick, so a throwing registry would otherwise stop the probe behind
+it from ever running.
+
+```ts sample
+import { DI } from '@spinajs/di';
+import { OrmDriver, ormMetrics, ORM_METRIC_POOL_SIZE, ORM_METRIC_CONNECTION_STATE } from '@spinajs/orm';
+
+export function metrics() {
+  const driver = DI.resolve<OrmDriver>('OrmConnection', ['default'])!;
+
+  // Force a publish outside the health tick.
+  driver.publishPoolMetrics();
+
+  return {
+    // null when the Metrics service cannot be resolved — never throws.
+    defined: ormMetrics() !== null,
+    names: [ORM_METRIC_POOL_SIZE, ORM_METRIC_CONNECTION_STATE],
+  };
+}
+```
+
+The ORM depends on `@spinajs/telemetry-common`, **not** `@spinajs/telemetry`. The latter pulls in
+`@spinajs/http`, `log`, `validation` and `configuration`, and putting the HTTP stack underneath
+every database connection inverts the dependency graph.
+
+`defineMetrics` rebuilds its metric objects on every call, so a second call would silently reset
+every value. The ORM therefore builds its set once per `Metrics` **service instance**, tracked in
+a `WeakMap` — keyed on the instance rather than a module flag, so `DI.clearCache()` (tests, or
+two SpinaJS apps in one process) starts from a fresh registry without leaking across it.
+
+### Reporting pool state from a custom driver
+
+`poolMetrics()` returns an empty pool by default; a driver owning a real pool overrides it. It
+**must never throw** — it runs on the health-check timer.
+
+```ts sample
+import { SqlDriver } from '@spinajs/orm-sql';
+import { IPoolMetrics, QueryContext } from '@spinajs/orm';
+
+export abstract class PooledDriver extends SqlDriver {
+  public abstract executeOnDb(stmt: string | object, params: unknown[], context: QueryContext): Promise<unknown>;
+
+  public poolMetrics(): IPoolMetrics {
+    return { Size: 10, InUse: 3, Waiting: 0 };
+  }
+
+  protected async acquire(): Promise<void> {
+    const started = process.hrtime.bigint();
+    // ... take a connection from the pool ...
+    const seconds = Number(process.hrtime.bigint() - started) / 1e9;
+
+    // Keeping the prom-client objects behind this method is what stops every driver
+    // from needing to know about @spinajs/telemetry-common.
+    this.observeAcquireSeconds(seconds);
+  }
+}
+```
+
+## Query timing
+
+`SqlDriver.execute` wraps every statement in `Perf.measure('orm.query', ...)` from
+`@spinajs/log-common`, labelled with `driver` and `context` (the `QueryContext`), and carrying
+the SQL and bindings as fields. Enable perf logging in your logger configuration to see them.
+
+`QueryContext` values: `Select`, `Insert`, `Update`, `Delete`, `Schema`, `Transaction`, `Upsert`,
+`InsertReturning`.
+
+## Logging
+
+Each driver resolves a logger named `orm-driver-<Name>` with `orm-name`, `orm-host` and
+`orm-database` bound as variables, so every line carries its connection.
+
+`Orm` itself logs under `ORM`: migration progress at `info`, each created connection at
+`success`, and missing connections or disabled migrations at `warn`.
+
+Connection parameters are logged as JSON restricted to `Database`, `User`, `Host`, `Port`,
+`Filename`, `Driver` and `Name`. **`Password` is never logged.**
+
+A failed statement is logged at `error` with the message, stack, model name and query context
+before the error is re-thrown.
+
+## Debugging a query
+
+```ts sample
+import { Connection, Model, ModelBase, Primary, ICompilerOutput } from '@spinajs/orm';
+
+@Connection('default')
+@Model('orders')
+export class Order extends ModelBase<Order> {
+  @Primary()
+  public Id: number;
+
+  public Status: string;
+}
+
+export function showSql() {
+  const query = Order.where('Status', 'open').take(10);
+
+  // Compile without executing. Idempotent — safe to call before awaiting the builder.
+  const compiled = query.toDB() as ICompilerOutput;
+
+  return { sql: compiled.expression, bindings: compiled.bindings };
+}
+```
+
+`toDB()` does not consume the builder, so you can log the SQL and then still `await` it.

--- a/packages/orm/docs/README.md
+++ b/packages/orm/docs/README.md
@@ -1,0 +1,70 @@
+# `@spinajs/orm` documentation
+
+The ORM core: model metadata, query builders, relations, the unit of work, and the schema /
+migration layer. It contains no SQL — dialects live in [`@spinajs/orm-sql`](../../orm-sql/docs/)
+and the driver packages below it.
+
+## Reading order
+
+Start at the top if the ORM is new to you. Each page stands alone once you have read
+[01-getting-started.md](01-getting-started.md).
+
+| | Page | What it covers |
+| --- | --- | --- |
+| 01 | [Getting started](01-getting-started.md) | Install, configure a connection, define a model and a migration, run the first query |
+| 02 | [Configuration](02-configuration.md) | `db.Connections`, pools, resilience, migration options, aliases, discovery |
+| 03 | [Models and decorators](03-models-and-decorators.md) | Every decorator, the model descriptor, inheritance rules |
+| 04 | [Static model API](04-static-model-api.md) | `Model.where()`, `get`, `insert`, `count`, `destroy`, … — the whole static surface |
+| 05 | [Instance API](05-instance-api.md) | `insert`, `update`, `save`, `destroy`, dirty tracking, snapshots, dehydration |
+| 06 | [Query builder](06-query-builder.md) | Select / insert / update / delete builders, `where` family, joins, aggregates, raw SQL |
+| 07 | [Relations](07-relations.md) | `@BelongsTo`, `@HasMany`, `@HasManyToMany`, `@Recursive`, `@Query`, `@Virtual`, populate |
+| 08 | [Unit of work](08-unit-of-work.md) | What `save()` does: subject building, sorting, execution, orphan policy, identity map |
+| 09 | [Transactions](09-transactions.md) | `transaction()`, nesting via savepoints, isolation levels |
+| 10 | [Schema and migrations](10-schema-and-migrations.md) | Migration lifecycle and the complete schema builder surface |
+| 11 | [Converters and hydration](11-converters-and-hydration.md) | Value converters, hydrators, dehydrators, model↔SQL conversion |
+| 12 | [Architecture](12-architecture.md) | How a query becomes SQL, the DI registration map, middleware hooks |
+| 13 | [Observability](13-observability.md) | Metrics, connection state, retry and health checks, logging |
+
+## The shortest possible example
+
+```ts sample
+import { Connection, Model, ModelBase, Primary, CreatedAt } from '@spinajs/orm';
+import { DateTime } from 'luxon';
+
+@Connection('default')
+@Model('users')
+export class User extends ModelBase<User> {
+  @Primary()
+  public Id: number;
+
+  public Email: string;
+
+  @CreatedAt()
+  public CreatedAt: DateTime;
+}
+
+export async function example() {
+  const user = await User.getOrCreate(null, { Email: 'someone@example.com' });
+  const active = await User.where('Email', 'like', '%@example.com').orderByDescending('CreatedAt').take(10);
+
+  return { user, active };
+}
+```
+
+## Related packages
+
+- [`@spinajs/orm-sql`](../../orm-sql/docs/) — the shared SQL statement and compiler layer
+- [`@spinajs/orm-sqlite`](../../orm-sqlite/docs/), [`@spinajs/orm-mysql`](../../orm-mysql/docs/),
+  [`@spinajs/orm-mssql`](../../orm-mssql/docs/) — dialect drivers
+- [`@spinajs/orm-http`](../../orm-http/docs/) — exposing models over HTTP
+- [`@spinajs/orm-api`](../../orm-api/docs/) — CRUD controller building blocks
+
+## Verifying the samples
+
+Every fenced block marked ` ```ts sample ` in these files is extracted and type-checked
+against the built packages:
+
+```bash
+npm run build        # packages resolve to each other's lib/ output
+npm run docs:check
+```

--- a/packages/orm/package.json
+++ b/packages/orm/package.json
@@ -24,7 +24,7 @@
     "clean": "rimraf lib/ && rimraf tsconfig.tsbuildinfo",
     "test": "ts-mocha -p tsconfig.json test/**/*.test.ts",
     "coverage": "nyc npm run test",
-    "build-docs": "rimraf docs && typedoc --options typedoc.json src/",
+    "build-docs": "rimraf api-docs && typedoc --options typedoc.json src/",
     "format": "prettier --write \"src/**/*.ts\"",
     "lint": "eslint -c .eslintrc.cjs --ext .ts src --fix",
     "preversion": "npm run lint",

--- a/packages/orm/typedoc.json
+++ b/packages/orm/typedoc.json
@@ -1,6 +1,6 @@
 {
     "mode": "modules",
-    "out": "docs",
+    "out": "api-docs",
     "name": "spine",
     "theme": "default",
     "ignoreCompilerErrors": "true",

--- a/scripts/check-doc-samples.mjs
+++ b/scripts/check-doc-samples.mjs
@@ -1,0 +1,182 @@
+#!/usr/bin/env node
+/**
+ * Type-checks the TypeScript samples embedded in the packages' `docs/` markdown.
+ *
+ * A fenced block participates only when its info string is exactly `ts sample`:
+ *
+ *     ```ts sample
+ *     import { Model, ModelBase } from '@spinajs/orm';
+ *     ...
+ *     ```
+ *
+ * Such a block must stand on its own — it carries its own imports and declares
+ * everything it references. Blocks fenced as plain ```ts are deliberately partial
+ * and are skipped, as is every non-TypeScript fence.
+ *
+ * Each block is written to .tmp/docs-samples/<package>/<doc>-<n>.ts and the whole
+ * directory is compiled once with `tsc --noEmit`. Diagnostics are mapped back to
+ * the markdown file and line the block came from.
+ *
+ * Because the workspace resolves @spinajs/* through symlinks into each package's
+ * built `lib/`, run `npm run build` before this.
+ *
+ * Usage:  node scripts/check-doc-samples.mjs [packageName ...]
+ */
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { dirname, join, relative, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const PACKAGES = join(ROOT, 'packages');
+const OUT = join(ROOT, '.tmp', 'docs-samples');
+
+const FENCE = /^([ \t]*)```([^\n`]*)\n([\s\S]*?)\n?\1```[ \t]*$/gm;
+const SAMPLE_INFO = /^ts\s+sample$/;
+
+const only = process.argv.slice(2);
+
+function markdownFiles(dir) {
+  const found = [];
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return found;
+  }
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) found.push(...markdownFiles(full));
+    else if (entry.name.endsWith('.md')) found.push(full);
+  }
+  return found;
+}
+
+/** Extracts every `ts sample` block, with the 1-based line its body starts on. */
+function extract(source) {
+  const blocks = [];
+  FENCE.lastIndex = 0;
+  let match;
+  while ((match = FENCE.exec(source)) !== null) {
+    const [, indent, info, body] = match;
+    if (!SAMPLE_INFO.test(info.trim())) continue;
+    // +1 because the opening fence itself occupies a line.
+    const line = source.slice(0, match.index).split('\n').length + 1;
+    const dedented = indent ? body.replace(new RegExp(`^${indent}`, 'gm'), '') : body;
+    blocks.push({ line, body: dedented });
+  }
+  return blocks;
+}
+
+function collect() {
+  const samples = [];
+  let packages;
+  try {
+    packages = readdirSync(PACKAGES, { withFileTypes: true })
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name);
+  } catch {
+    console.error(`no packages directory at ${PACKAGES}`);
+    process.exit(1);
+  }
+
+  for (const pkg of packages) {
+    if (only.length && !only.includes(pkg)) continue;
+    const docs = join(PACKAGES, pkg, 'docs');
+    try {
+      if (!statSync(docs).isDirectory()) continue;
+    } catch {
+      continue;
+    }
+
+    for (const md of markdownFiles(docs)) {
+      const source = readFileSync(md, 'utf8');
+      const stem = relative(docs, md).replace(/\.md$/, '').split(sep).join('-');
+      extract(source).forEach((block, index) => {
+        samples.push({
+          pkg,
+          markdown: relative(ROOT, md),
+          markdownLine: block.line,
+          file: join(OUT, pkg, `${stem}-${index + 1}.ts`),
+          body: block.body,
+        });
+      });
+    }
+  }
+  return samples;
+}
+
+const samples = collect();
+
+if (samples.length === 0) {
+  console.log('no `ts sample` blocks found — nothing to check');
+  process.exit(0);
+}
+
+rmSync(OUT, { recursive: true, force: true });
+for (const sample of samples) {
+  mkdirSync(dirname(sample.file), { recursive: true });
+  writeFileSync(sample.file, `${sample.body}\n`, 'utf8');
+}
+
+// Mirrors the packages' own tsconfig, minus the rules that only make sense for
+// shipped code: a documentation sample legitimately imports a symbol to show the
+// import line, and legitimately declares a parameter it does not use.
+writeFileSync(
+  join(OUT, 'tsconfig.json'),
+  `${JSON.stringify(
+    {
+      compilerOptions: {
+        target: 'ES2021',
+        module: 'NodeNext',
+        moduleResolution: 'NodeNext',
+        lib: ['esnext', 'dom'],
+        noEmit: true,
+        strictNullChecks: true,
+        noImplicitAny: true,
+        noUnusedLocals: false,
+        noUnusedParameters: false,
+        esModuleInterop: true,
+        allowSyntheticDefaultImports: true,
+        skipLibCheck: true,
+        useDefineForClassFields: false,
+        experimentalDecorators: true,
+        emitDecoratorMetadata: true,
+        baseUrl: '.',
+        typeRoots: [join(ROOT, 'node_modules', '@types')],
+        types: ['node'],
+      },
+      include: ['**/*.ts'],
+    },
+    null,
+    2,
+  )}\n`,
+  'utf8',
+);
+
+const tsc = process.platform === 'win32' ? 'tsc.cmd' : 'tsc';
+const result = spawnSync(join(ROOT, 'node_modules', '.bin', tsc), ['--noEmit', '-p', join(OUT, 'tsconfig.json')], {
+  cwd: ROOT,
+  encoding: 'utf8',
+  shell: process.platform === 'win32',
+});
+
+const output = `${result.stdout ?? ''}${result.stderr ?? ''}`;
+
+if (result.status === 0) {
+  console.log(`docs:check ok — ${samples.length} sample(s) compiled`);
+  process.exit(0);
+}
+
+// tsc reports against the generated file; translate back to the markdown source so
+// the reader is pointed at the block they have to fix.
+const byFile = new Map(samples.map((s) => [relative(ROOT, s.file).split(sep).join('/'), s]));
+const translated = output.replace(/^(\S+?\.ts)\((\d+),(\d+)\)/gm, (whole, file, line, column) => {
+  const sample = byFile.get(file.split(sep).join('/'));
+  if (!sample) return whole;
+  return `${sample.markdown}(${sample.markdownLine + Number(line) - 1},${column}) [${file}]`;
+});
+
+console.error(translated.trim());
+console.error(`\ndocs:check FAILED — ${samples.length} sample(s) checked`);
+process.exit(1);


### PR DESCRIPTION
Every ORM package shipped a `> TODO: description` README and an unused typedoc config. This adds 42 prose documents across seven packages, plus a harness that type-checks every code sample against the built libraries.

Coverage:

- orm         13 pages: getting started, configuration, decorators, static and
              instance APIs, query builder, relations, unit of work, transactions,
              schema/migrations, converters/hydration, architecture, observability
- orm-sql      4 pages: overview, compilers, statements, writing a dialect driver
- orm-http     6 pages: route args, filtering, DTO relations, paging, middleware
- orm-api      5 pages: overview, config, building a CRUD controller, query args,
              transformers and policies
- orm-sqlite   2 pages, orm-mysql 2 pages, orm-mssql 2 pages: configuration and
              dialect notes

Sample verification: scripts/check-doc-samples.mjs extracts every ```ts sample block, writes it to .tmp/docs-samples/ and runs tsc --noEmit against the built lib/ output, mapping diagnostics back to the markdown line. Wired as `npm run docs:check` at the repo root. 152 samples currently compile.

Typedoc output relocated from docs/ to api-docs/ in all seven packages. docs/ was both gitignored and `rimraf`'d by build-docs, so prose placed there would never be committed and would be destroyed by the next docs build. Prose is source; generated HTML is an artifact, so the artifact moved.

Behaviour is documented as it is, including several defects found while reading the source:

- orm-mssql registers no ServerResponseMapper, so every insert path throws. Its own suite fails 2 tests on this.
- orm-http and orm-api both define RepositoryMiddleware but export it from neither entry point, and nothing invokes it.
- orm-api's JsonApi CRUD controller is entirely commented out; its bundled config points at a non-existent controllers directory and names a transformer that is registered nowhere.
- orm-sqlite and orm-mssql silently reduce multi-column ORDER BY to one column.
- orm-mssql emits OFFSET/FETCH only when a limit is set, so skip() alone is a no-op.

No source behaviour was changed.