### PR TITLE
fix(fs): forward the extension through fsTemp.tmppath

### DIFF
--- a/packages/fs/src/temp-provider.ts
+++ b/packages/fs/src/temp-provider.ts
@@ -176,8 +176,11 @@ export class fsTemp extends fs {
     return this.Provider.list(path);
   }
 
-  public tmppath(): string {
-    return this.Provider.tmppath();
+  // `ext` must be forwarded: callers such as fsS3.download() pass extname(path) so the
+  // downloaded copy keeps its extension, and consumers pick behaviour from it (templates
+  // resolve their renderer by extension). Swallowing it here fails far from the cause.
+  public tmppath(ext?: string): string {
+    return this.Provider.tmppath(ext);
   }
 
   public append(path: string, data: string | Uint8Array, encoding?: BufferEncoding): Promise<void> {

--- a/packages/fs/test/fs.temp.test.ts
+++ b/packages/fs/test/fs.temp.test.ts
@@ -55,6 +55,16 @@ describe('fs temp tests', function () {
     expect(tmpPath.endsWith('packages\\fs\\test\\temp\\tmp.txt')).to.true;
   });
 
+  it('should keep the extension passed to tmppath', async () => {
+    const t = await tmp();
+
+    // fsS3.download() calls TempFs.tmppath(extname(path)) and hands the result to
+    // the template renderer, which picks an engine by extension. Dropping the
+    // extension here surfaces far away as "No renderer for file <uuid> with extension".
+    expect(t.tmppath('.mjml').endsWith('.mjml')).to.true;
+    expect(t.tmppath()).to.not.be.empty;
+  });
+
   it('should cleanup old temp file', async () => {
     await sleep(20 * 1000);
 


### PR DESCRIPTION
fsTemp declared tmppath() with no parameters while the abstract in interfaces.ts declares tmppath(ext?: string). TypeScript allows an override to drop trailing parameters, so the extension was silently discarded and never reached the backend provider, which handles it correctly.

fsS3.download() calls TempFs.tmppath(extname(path)) so the downloaded copy keeps its extension, then hands the path to whatever consumes the file. @spinajs/templates picks its renderer by extension, so a downloaded .mjml template arrived as a bare uuid and failed with "No renderer for file <uuid> with extension" - far from the cause, and only on providers that download ( local templates were unaffected, which is why tests over fsNative never caught it ).